### PR TITLE
Replace rabbitMQ config with new format (#10)

### DIFF
--- a/singularity/run.sh
+++ b/singularity/run.sh
@@ -14,9 +14,8 @@ export noProxy=${noProxy}
 
 
 # vars for rabbitmq-server
-export RABBITMQ_CONFIG_FILE=/data/dpdash/configs/rabbitmq
-export RABBITMQ_MNESIA_BASE=/data/dpdash/rabbitmq
-export RABBITMQ_LOG_BASE=/data/dpdash/rabbitmq
+export RABBITMQ_CONFIG_FILE=/data/dpdash/configs/rabbitmq.conf
+export RABBITMQ_CONF_ENV_FILE=/data/dpdash/configs/rabbitmq-env.conf
 
 # vars for celery worker
 export dppy_config=/data/dpdash/configs/dppy.conf

--- a/singularity/setup.sh
+++ b/singularity/setup.sh
@@ -20,12 +20,8 @@ mongod --shutdown --dbpath /data/dpdash/mongodb/dbs
 
 ## Set up Rabbitmq Server
 echo '***************Setting up RABBITMQ***************'
-export RABBITMQ_CONFIG_FILE=/data/dpdash/configs/rabbitmq.config
-export RABBITMQ_MNESIA_BASE=/data/dpdash/rabbitmq
-export RABBITMQ_LOG_BASE=/data/dpdash/rabbitmq
-export RABBITMQ_NODENAME=rabbit2
-export RABBITMQ_DIST_PORT=35672
-export RABBITMQ_NODE_PORT=5971
+export RABBITMQ_CONFIG_FILE=/data/dpdash/configs/rabbitmq.conf
+export RABBITMQ_CONF_ENV_FILE=/data/dpdash/configs/rabbitmq-env.conf
 /usr/lib/rabbitmq/bin/rabbitmq-server start -detached
 sleep 10 && /usr/lib/rabbitmq/bin/rabbitmqctl add_user dpdash $rabbitpw
 sleep 10 && /usr/lib/rabbitmq/bin/rabbitmqctl set_permissions -p / dpdash ".*" ".*" ".*"


### PR DESCRIPTION
* Define new args (w/ defaults) in configure.py
  relevant to these configs, "--rabbit-name" and
  "--rabbit-dist"
* In configure.py:
  - Store new format in rabbitmq.conf
  - Store applicable environment variables in
    rabbitmq-env.conf
* Update setup.sh and run.sh to reflect new paths