### PR TITLE
Update MongoDB from 3.6 to 4.4, + other dependencies

### DIFF
--- a/README-PNL.md
+++ b/README-PNL.md
@@ -167,7 +167,7 @@ After `import.py`, you can verify if your data went inside mongo database:
 
     singularity shell -B ${state}:/data -B ${data}:/project_data ${DPDASH_IMG}
 
-    Singularity> mongo --ssl --host `hostname` --sslCAFile /data/ssl/ca/cacert.pem --sslPEMKeyFile /data/ssl/mongo_client.pem
+    Singularity> mongo --tls --host `hostname` --tlsCAFile /data/ssl/ca/cacert.pem --tlsCertificateKeyFile /data/ssl/mongo_client.pem
 
 
 Inside mongo shell:
@@ -186,7 +186,7 @@ Inside mongo shell:
 Assuming you have imported one `BLS_metadata.csv` file into the mongo database, take a look at the following example 
 to learn how `dpdash` user is given access to the `BLS` study:
  
-    Singularity> mongo --ssl --host `hostname` --sslCAFile /data/ssl/ca/cacert.pem --sslPEMKeyFile /data/ssl/mongo_client.pem
+    Singularity> mongo --tls --host `hostname` --sslCAFile /data/ssl/ca/cacert.pem --sslPEMKeyFile /data/ssl/mongo_client.pem
 
 Inside mongo shell:
  

--- a/README-PNL.md
+++ b/README-PNL.md
@@ -186,7 +186,7 @@ Inside mongo shell:
 Assuming you have imported one `BLS_metadata.csv` file into the mongo database, take a look at the following example 
 to learn how `dpdash` user is given access to the `BLS` study:
  
-    Singularity> mongo --tls --host `hostname` --sslCAFile /data/ssl/ca/cacert.pem --sslPEMKeyFile /data/ssl/mongo_client.pem
+    Singularity> mongo --tls --host `hostname` --tlsCAFile /data/ssl/ca/cacert.pem --tlsCertificateKeyFile /data/ssl/mongo_client.pem
 
 Inside mongo shell:
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@material-ui/core": "^3.3.0",
         "@material-ui/icons": "^3.0.1",
-        "amqplib": "^0.7.1",
+        "amqplib": "^0.8.0",
         "body-parser": "^1.18.3",
         "classnames": "^2.2.6",
         "co": "^4.6.0",
@@ -2933,10 +2933,9 @@
       }
     },
     "node_modules/amqplib": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.7.1.tgz",
-      "integrity": "sha512-KePK3tTOLGU4emTo+PwSDMbc123jrxo13FpRpim1LzJoSlQrIBB2/kMeCC40jK/Zb0olHGaABjLqXDsdK46iLA==",
-      "license": "MIT",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.8.0.tgz",
+      "integrity": "sha512-icU+a4kkq4Y1PS4NNi+YPDMwdlbFcZ1EZTQT2nigW3fvOb6AOgUQ9+Mk4ue0Zu5cBg/XpDzB40oH10ysrk2dmA==",
       "dependencies": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.7.2",
@@ -2946,7 +2945,7 @@
         "url-parse": "~1.5.1"
       },
       "engines": {
-        "node": ">=0.8 <=15"
+        "node": ">=10"
       }
     },
     "node_modules/amqplib/node_modules/isarray": {
@@ -13167,9 +13166,9 @@
       }
     },
     "amqplib": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.7.1.tgz",
-      "integrity": "sha512-KePK3tTOLGU4emTo+PwSDMbc123jrxo13FpRpim1LzJoSlQrIBB2/kMeCC40jK/Zb0olHGaABjLqXDsdK46iLA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.8.0.tgz",
+      "integrity": "sha512-icU+a4kkq4Y1PS4NNi+YPDMwdlbFcZ1EZTQT2nigW3fvOb6AOgUQ9+Mk4ue0Zu5cBg/XpDzB40oH10ysrk2dmA==",
       "requires": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "immutability-helper": "^2.8.1",
         "jsonschema": "^1.2.4",
         "material-ui-chip-input": "^1.0.0-beta.8",
-        "mathjs": "^5.2.1",
+        "mathjs": "^7.6.0",
         "method-override": "^3.0.0",
         "moment": "^2.22.2",
         "mongodb": "^3.6.6",
@@ -4672,9 +4672,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decimal.js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.0.1.tgz",
-      "integrity": "sha512-vklWB5C4Cj423xnaOtsUmAv0/7GqlXIgDv2ZKDyR64OV3OSzGHNx2mk4p/1EKnB5s70k73cIOOEcG9YzF0q4Lw=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
@@ -4906,9 +4906,9 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dependencies": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
@@ -4919,7 +4919,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },
@@ -5035,9 +5035,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-latex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.1.1.tgz",
-      "integrity": "sha512-N2D6Z2kXh8x/pQNQH+natXDCwrzghhXMRII5dZ518mlTLeuba80NL0LCQyaahqOrAidoLivmmG6GKPnGhHse+A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -5682,9 +5682,9 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.10.tgz",
-      "integrity": "sha512-MHkhk6ggCtwVhKR4pbF+aWrV+8cIVxyWhucESF/1NEcYDgRm4oze/2M09yGTGUQ3WQyZSdcoswJSThc2VGb+KQ==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
+      "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA==",
       "engines": {
         "node": "*"
       }
@@ -6869,24 +6869,24 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.2.1.tgz",
-      "integrity": "sha512-l+imExQ09Jj6Mz/YX8LbCb3Q32kjvYq5HQmUhMonuwhSU3o5XKvcnW6T6OzXkD+xadH2/Qg4zXC1ejI1MYcJeg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-7.6.0.tgz",
+      "integrity": "sha512-abywR28hUpKF4at5jE8Ys+Kigk40eKMT5mcBLD0/dtsqjfOLbtzd3WjlRqIopNo7oQ6FME51qph6lb8h/bhpUg==",
       "dependencies": {
-        "complex.js": "2.0.11",
-        "decimal.js": "10.0.1",
-        "escape-latex": "1.1.1",
-        "fraction.js": "4.0.10",
-        "javascript-natural-sort": "0.7.1",
-        "seed-random": "2.2.0",
-        "tiny-emitter": "2.0.2",
-        "typed-function": "1.1.0"
+        "complex.js": "^2.0.11",
+        "decimal.js": "^10.2.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.0.12",
+        "javascript-natural-sort": "^0.7.1",
+        "seed-random": "^2.2.0",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.0.0"
       },
       "bin": {
         "mathjs": "bin/cli.js"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/media-typer": {
@@ -9761,9 +9761,9 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "node_modules/tiny-emitter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/to-array": {
       "version": "0.1.4",
@@ -9879,11 +9879,11 @@
       }
     },
     "node_modules/typed-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
-      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 8"
       }
     },
     "node_modules/typedarray": {
@@ -9892,9 +9892,19 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
       "engines": {
         "node": "*"
       }
@@ -10669,9 +10679,9 @@
       }
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -14628,9 +14638,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.0.1.tgz",
-      "integrity": "sha512-vklWB5C4Cj423xnaOtsUmAv0/7GqlXIgDv2ZKDyR64OV3OSzGHNx2mk4p/1EKnB5s70k73cIOOEcG9YzF0q4Lw=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -14844,9 +14854,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "requires": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
@@ -14857,7 +14867,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -14938,9 +14948,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-latex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.1.1.tgz",
-      "integrity": "sha512-N2D6Z2kXh8x/pQNQH+natXDCwrzghhXMRII5dZ518mlTLeuba80NL0LCQyaahqOrAidoLivmmG6GKPnGhHse+A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -15457,9 +15467,9 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fraction.js": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.10.tgz",
-      "integrity": "sha512-MHkhk6ggCtwVhKR4pbF+aWrV+8cIVxyWhucESF/1NEcYDgRm4oze/2M09yGTGUQ3WQyZSdcoswJSThc2VGb+KQ=="
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
+      "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -16434,18 +16444,18 @@
       }
     },
     "mathjs": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.2.1.tgz",
-      "integrity": "sha512-l+imExQ09Jj6Mz/YX8LbCb3Q32kjvYq5HQmUhMonuwhSU3o5XKvcnW6T6OzXkD+xadH2/Qg4zXC1ejI1MYcJeg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-7.6.0.tgz",
+      "integrity": "sha512-abywR28hUpKF4at5jE8Ys+Kigk40eKMT5mcBLD0/dtsqjfOLbtzd3WjlRqIopNo7oQ6FME51qph6lb8h/bhpUg==",
       "requires": {
-        "complex.js": "2.0.11",
-        "decimal.js": "10.0.1",
-        "escape-latex": "1.1.1",
-        "fraction.js": "4.0.10",
-        "javascript-natural-sort": "0.7.1",
-        "seed-random": "2.2.0",
-        "tiny-emitter": "2.0.2",
-        "typed-function": "1.1.0"
+        "complex.js": "^2.0.11",
+        "decimal.js": "^10.2.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.0.12",
+        "javascript-natural-sort": "^0.7.1",
+        "seed-random": "^2.2.0",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.0.0"
       }
     },
     "media-typer": {
@@ -18804,9 +18814,9 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "tiny-emitter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "to-array": {
       "version": "0.1.4",
@@ -18897,9 +18907,9 @@
       }
     },
     "typed-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
-      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -18907,9 +18917,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -19515,9 +19525,9 @@
       "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@material-ui/core": "^3.3.0",
     "@material-ui/icons": "^3.0.1",
-    "amqplib": "^0.7.1",
+    "amqplib": "^0.8.0",
     "body-parser": "^1.18.3",
     "classnames": "^2.2.6",
     "co": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "immutability-helper": "^2.8.1",
     "jsonschema": "^1.2.4",
     "material-ui-chip-input": "^1.0.0-beta.8",
-    "mathjs": "^5.2.1",
+    "mathjs": "^7.6.0",
     "method-override": "^3.0.0",
     "moment": "^2.22.2",
     "mongodb": "^3.6.6",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -383,10 +383,32 @@ router.get('/dashboard/:study/:subject', ensurePermission, function (req, res) {
                           var encrypted = createHash('sha256').update(collectionName).digest('hex');
                           var varName = default_config[configItem].variable;
                           var escapedVarName = encodeURIComponent(varName).replace(/\./g, '%2E');
-                          var query = '[{ $project: {_id: 0, day: 1, "' + escapedVarName + '" : "$' + varName + '"}}]';
-                          var data = yield mongoData.collection(encrypted.toString()).aggregate(eval(query)).toArray();
-                          var queryForStat = '[{ $match : {"' + escapedVarName + '" : { $ne: "" }}},{ $group : { _id: "$null", min: {$min : "$' + escapedVarName + '"}, max: {$max : "$' + escapedVarName + '"}, mean: {$avg : "$' + escapedVarName + '"}}}]';
-                          var stat = yield mongoData.collection(encrypted.toString()).aggregate(eval(queryForStat)).toArray();
+                          const query = [{
+                            $project: { _id: 0, day: 1, [escapedVarName]: `$${varName}` }
+                          }];
+                          var data = yield mongoData.collection(encrypted.toString()).aggregate(query).toArray();
+                          const queryForStat = [
+                            {
+                              $match: {
+                                [escapedVarName]: { $ne: '' }
+                              }
+                            },
+                            {
+                              $group: {
+                                _id: null,
+                                min: {
+                                  $min: `$${escapedVarName}`
+                                },
+                                max: {
+                                  $max: `$${escapedVarName}`
+                                },
+                                mean: {
+                                  $avg: `$${escapedVarName}`
+                                }
+                              }
+                            }
+                          ]
+                          var stat = yield mongoData.collection(encrypted.toString()).aggregate(queryForStat).toArray();
                           var dataPiece = {};
                           dataPiece.text = default_config[configItem].text;
                           dataPiece.analysis = default_config[configItem].analysis;
@@ -444,10 +466,32 @@ router.get('/dashboard/:study/:subject', ensurePermission, function (req, res) {
                     var encrypted = createHash('sha256').update(collectionName).digest('hex');
                     var varName = default_config[configItem].variable;
                     var escapedVarName = encodeURIComponent(varName).replace(/\./g, '%2E');
-                    var query = '[{ $project: {_id: 0, day: 1, "' + escapedVarName + '" : "$' + varName + '"}}]';
-                    var data = yield mongoData.collection(encrypted.toString()).aggregate(eval(query)).toArray();
-                    var queryForStat = '[{ $match : {"' + escapedVarName + '" : { $ne: "" }}},{ $group : { _id: "$null", min: {$min : "$' + escapedVarName + '"}, max: {$max : "$' + escapedVarName + '"}, mean: {$avg : "$' + escapedVarName + '"}}}]';
-                    var stat = yield mongoData.collection(encrypted.toString()).aggregate(eval(queryForStat)).toArray();
+                    const query = [{
+                            $project: { _id: 0, day: 1, [escapedVarName]: `$${varName}` }
+                          }];
+                    var data = yield mongoData.collection(encrypted.toString()).aggregate(query).toArray();
+                    const queryForStat = [
+                            {
+                              $match: {
+                                [escapedVarName]: { $ne: '' }
+                              }
+                            },
+                            {
+                              $group: {
+                                _id: null,
+                                min: {
+                                  $min: `$${escapedVarName}`
+                                },
+                                max: {
+                                  $max: `$${escapedVarName}`
+                                },
+                                mean: {
+                                  $avg: `$${escapedVarName}`
+                                }
+                              }
+                            }
+                          ];
+                    var stat = yield mongoData.collection(encrypted.toString()).aggregate(queryForStat).toArray();
                     var dataPiece = {};
                     dataPiece.text = default_config[configItem].text;
                     dataPiece.analysis = default_config[configItem].analysis;
@@ -515,10 +559,32 @@ router.get('/dashboard/:study/:subject', ensurePermission, function (req, res) {
                     var encrypted = createHash('sha256').update(collectionName).digest('hex');
                     var varName = default_config[configItem].variable;
                     var escapedVarName = encodeURIComponent(varName).replace(/\./g, '%2E');
-                    var query = '[{ $project: {_id: 0, day: 1, "' + escapedVarName + '" : "$' + varName + '"}}]';
-                    var data = yield mongoData.collection(encrypted.toString()).aggregate(eval(query)).toArray();
-                    var queryForStat = '[{ $match : {"' + escapedVarName + '" : { $ne: "" }}},{ $group : { _id: "$null", min: {$min : "$' + escapedVarName + '"}, max: {$max : "$' + escapedVarName + '"}, mean: {$avg : "$' + escapedVarName + '"}}}]';
-                    var stat = yield mongoData.collection(encrypted.toString()).aggregate(eval(queryForStat)).toArray();
+                    const query = [{
+                            $project: { _id: 0, day: 1, [escapedVarName]: `$${varName}` }
+                          }];
+                    var data = yield mongoData.collection(encrypted.toString()).aggregate(query).toArray();
+                    const queryForStat = [
+                            {
+                              $match: {
+                                [escapedVarName]: { $ne: '' }
+                              }
+                            },
+                            {
+                              $group: {
+                                _id: null,
+                                min: {
+                                  $min: `$${escapedVarName}`
+                                },
+                                max: {
+                                  $max: `$${escapedVarName}`
+                                },
+                                mean: {
+                                  $avg: `$${escapedVarName}`
+                                }
+                              }
+                            }
+                          ];
+                    var stat = yield mongoData.collection(encrypted.toString()).aggregate(queryForStat).toArray();
                     var dataPiece = {};
                     dataPiece.text = default_config[configItem].text;
                     dataPiece.analysis = default_config[configItem].analysis;
@@ -654,10 +720,32 @@ router.get('/dashboard/:study', ensurePermission, function (req, res) {
 
         var varName = configs_heatmap[configItem].variable;
         var escapedVarName = encodeURIComponent(varName).replace(/\./g, '%2E');
-        var query = '[{ $project: {_id: 0, day: 1, "' + escapedVarName + '" : "$' + varName + '"}}]';
-        var data = yield mongoData.collection(encrypted.toString()).aggregate(eval(query)).toArray();
-        var queryForStat = '[{ $match : {"' + escapedVarName + '" : { $ne: "" }}},{ $group : { _id: "$null", min: {$min : "$' + escapedVarName + '"}, max: {$max : "$' + escapedVarName + '"}, mean: {$avg : "$' + escapedVarName + '"}}}]';
-        var stat = yield mongoData.collection(encrypted.toString()).aggregate(eval(queryForStat)).toArray();
+        const query = [{
+                            $project: { _id: 0, day: 1, [escapedVarName]: `$${varName}` }
+                          }];
+        var data = yield mongoData.collection(encrypted.toString()).aggregate(query).toArray();
+        const queryForStat = [
+                            {
+                              $match: {
+                                [escapedVarName]: { $ne: '' }
+                              }
+                            },
+                            {
+                              $group: {
+                                _id: null,
+                                min: {
+                                  $min: `$${escapedVarName}`
+                                },
+                                max: {
+                                  $max: `$${escapedVarName}`
+                                },
+                                mean: {
+                                  $avg: `$${escapedVarName}`
+                                }
+                              }
+                            }
+                          ];
+        var stat = yield mongoData.collection(encrypted.toString()).aggregate(queryForStat).toArray();
         var dataPiece = {};
         dataPiece.text = configs_heatmap[configItem].text;
         dataPiece.analysis = configs_heatmap[configItem].analysis;

--- a/server/utils/mongoUtil.js
+++ b/server/utils/mongoUtil.js
@@ -3,6 +3,7 @@ const getMongoURI = ({ settings }) => {
   mongoURI = mongoURI + settings.password + '@' + settings.host;
   mongoURI = mongoURI + ':' + settings.port + '/' + settings.appDB;
   mongoURI = mongoURI + '?authSource=' + settings.authSource;
+  mongoURI = mongoURI + '&tls=' + settings.server.ssl;
 
   return mongoURI;
 }

--- a/server/utils/mongoUtil.js
+++ b/server/utils/mongoUtil.js
@@ -3,7 +3,6 @@ const getMongoURI = ({ settings }) => {
   mongoURI = mongoURI + settings.password + '@' + settings.host;
   mongoURI = mongoURI + ':' + settings.port + '/' + settings.appDB;
   mongoURI = mongoURI + '?authSource=' + settings.authSource;
-  mongoURI = mongoURI + '&tls=' + settings.server.ssl;
 
   return mongoURI;
 }

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -43,12 +43,12 @@ From:centos:7.4.1708
     yum -y install nodejs
 
     ## install the MongoDB document database
-    echo -e "[mongodb-org-4.0]
+    echo -e "[mongodb-org-4.2]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.0/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.2/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc" >> /etc/yum.repos.d/mongodb-org-4.0.repo
+gpgkey=https://www.mongodb.org/static/pgp/server-4.2.asc" >> /etc/yum.repos.d/mongodb-org-4.2.repo
 
     yum -y install mongodb-org
     

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -66,6 +66,9 @@ gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc" >> /etc/yum.repos.d/mo
     n auto
     export PATH=/usr/local/bin/node:$PATH
     
+    ## use latest version of npm
+    npm install -g npm@latest
+
     ## install and build DPdash
     npm install
     npm run build

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -43,12 +43,12 @@ From:centos:7.4.1708
     yum -y install nodejs
 
     ## install the MongoDB document database
-    echo -e "[mongodb-org-3.4]
+    echo -e "[mongodb-org-3.6]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.6/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc" >> /etc/yum.repos.d/mongodb-org-3.4.repo
+gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc" >> /etc/yum.repos.d/mongodb-org-3.6.repo
 
     yum -y install mongodb-org
     

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -43,12 +43,12 @@ From:centos:7.4.1708
     yum -y install nodejs
 
     ## install the MongoDB document database
-    echo -e "[mongodb-org-3.6]
+    echo -e "[mongodb-org-4.0]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.6/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc" >> /etc/yum.repos.d/mongodb-org-3.6.repo
+gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc" >> /etc/yum.repos.d/mongodb-org-4.0.repo
 
     yum -y install mongodb-org
     

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -43,12 +43,12 @@ From:centos:7.4.1708
     yum -y install nodejs
 
     ## install the MongoDB document database
-    echo -e "[mongodb-org-4.2]
+    echo -e "[mongodb-org-4.4]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.4/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-4.2.asc" >> /etc/yum.repos.d/mongodb-org-4.2.repo
+gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc" >> /etc/yum.repos.d/mongodb-org-4.4.repo
 
     yum -y install mongodb-org
     

--- a/singularity/configure.py
+++ b/singularity/configure.py
@@ -108,9 +108,9 @@ storage:
 net:
   port: %(mongo_port)s
   bindIp: localhost,/tmp/mongodb-%(mongo_port)s.sock,%(mongo_host)s
-  ssl:
-    mode: requireSSL
-    PEMKeyFile: %(mongocert_path)s
+  tls:
+    mode: requireTLS
+    certificateKeyFile: %(mongocert_path)s
     CAFile: %(ca_path)s
 systemLog:
    destination: file

--- a/singularity/start.sh
+++ b/singularity/start.sh
@@ -6,6 +6,10 @@ set -eo pipefail
 shellmode=false
 devmode=false
 
+# Getting environment variables from .env
+source ./loadenv.sh
+source ./varcheck.sh
+
 while getopts ":sd" opt; do
     case $opt in
         s)
@@ -26,10 +30,6 @@ while getopts ":sd" opt; do
             ;;
     esac
 done
-
-# Getting environment variables from .env
-source ./loadenv.sh
-source ./varcheck.sh
 
 if [ $shellmode = true ]
 then

--- a/views/EditConfig.react.js
+++ b/views/EditConfig.react.js
@@ -5,7 +5,7 @@ import 'whatwg-fetch';
 import update from 'immutability-helper';
 import * as _ from 'lodash';
 import colorbrewer from 'colorbrewer';
-import math from 'mathjs';
+import { bignumber, number, add, subtract, divide, abs } from 'mathjs';
 
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
@@ -440,23 +440,23 @@ class EditConfig extends Component {
     let config = this.state.config[this.state.configKey][row];
     let length = config['color'].length - 1;
     let range = config['range'];
-    let min = range[0] ? math.bignumber(range[0]) : 0;
-    let max = range[range.length - 1] ? math.bignumber(range[range.length - 1]) : math.add(min, 1);
-    max = math.number(min) === math.number(max) ? math.add(min, 1) : max;
+    let min = range[0] ? bignumber(range[0]) : 0;
+    let max = range[range.length - 1] ? bignumber(range[range.length - 1]) : add(min, 1);
+    max = number(min) === number(max) ? add(min, 1) : max;
 
-    let diff = math.subtract(max, min);
-    let interval = math.divide(math.abs(diff), length); //This forces linearity
-    max = math.number(max);
+    let diff = subtract(max, min);
+    let interval = divide(abs(diff), length); //This forces linearity
+    max = number(max);
 
     let newRange = [];
     let max_true = max >= min ? true : false;
     if (!max_true) {
-      for (min; min >= max; min = math.subtract(min, interval)) {
-        newRange.push(math.number(min));
+      for (min; min >= max; min = subtract(min, interval)) {
+        newRange.push(number(min));
       }
     } else {
-      for (min; min <= max; min = math.add(min, interval)) {
-        newRange.push(math.number(min));
+      for (min; min <= max; min = add(min, interval)) {
+        newRange.push(number(min));
       }
     }
     this.setState({


### PR DESCRIPTION
Closes #17 

(**Note**: despite branch name, this is primarily a MongoDB update, no RabbitMQ at all, that is still forthcoming)

## Changes

MongoDB related changes:
* Replace all deprecated SSL options with TLS replacements
* Replace all deprecated `eval` calls with proper query objects
* Generate new YAML config format in `configure.py`

Other dependencies:
* Bump ampqlib to 0.8.0 (fixes deprecation warning in install)
* Bump mathjs from 5.2.1 to 7.5.1 (fixes high-severity security vulnerability)
* Always use latest npm in Singularity build

Bugfixes:
* Fix `start.sh` script, load environment variables before checking if dev dir exists and is a directory

## Testing

- [x] upon every update, build the Singularity image from scratch
  - `/data/predict/dpdash-ben-0525.sif`
- [x] delete `${state}` directory
- [x] run `init.sh` which will regenerate `${state}`
- [x] `import.py` into mongodb
- [x] check the website for expected results, browse various URIs