### PR TITLE
Scripts: Fix quit.sh, add renewssl.sh for renewing SSL certs

### DIFF
--- a/singularity/quit.sh
+++ b/singularity/quit.sh
@@ -7,14 +7,16 @@ set -eo pipefail
 cd /sw/apps/dpdash
 npm stop
 
-# TODO: make this do a graceful exit
+# kill PM2
+./node_modules/pm2/bin/pm2 kill
 
-pkill -f 'pm2'
+# kill supervisord (thus mongo, celery, erlang, rabbitmq)
+echo "Quitting supervisord..."
+pidfile="/data/dpdash/supervisord/supervisord.pid"
+pid=$(<$pidfile)
+kill -SIGQUIT $pid
 
-# TODO: send SIGQUIT to supervisord
-
-pkill -f 'supervisord'
-pkill -f 'rabbitmq'
-pkill -f 'erlang'
-pkill -f 'celery'
-pkill -f 'mongo'
+while kill -s 0 $pid ; do : ; sleep 0.25 ; done
+green='\033[0;32m'
+NC='\033[0m'
+echo -e "${green}Quit complete.${NC}"

--- a/singularity/renewssl.sh
+++ b/singularity/renewssl.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Getting environment variables from .env
+source ./loadenv.sh
+# Check if required variables are defined
+source ./varcheck.sh
+
+containerDataDir=$state
+if [ ! -d $containerDataDir ]; then
+    echo "$containerDataDir does not exist"
+    exit 1
+fi
+if [ ! -z ${DPDASH_SERVICE_HOST} ]
+then 
+    serviceHost=$DPDASH_SERVICE_HOST
+else
+    serviceHost=`hostname -f | xargs`
+fi
+cd ${containerDataDir}/ssl/ca
+
+echo 'Revoking existing certs'
+dirpath=${containerDataDir}/ssl/ca/certs
+for certfile in "$dirpath"/*.pem; do
+    openssl ca -config openssl.cnf -revoke $certfile
+done
+
+echo 'Generating CAs'
+openssl req -x509 -config openssl.cnf -newkey rsa:4096 -days 365 \
+    -out cacert.pem -outform PEM -subj /CN=DPdashCA/ -nodes
+openssl x509 -in cacert.pem -out cacert.cer -outform DER
+
+echo 'Generating server keys'
+cd ../server
+openssl genrsa -out key.pem 4096
+openssl req -new -key key.pem -out req.pem -outform PEM \
+    -subj "/CN=${serviceHost}/O=server/" -nodes
+
+cd ../ca
+openssl ca -config openssl.cnf -in ../server/req.pem -out \
+    ../server/cert.pem -notext -batch -extensions server_ca_extensions
+
+echo 'Generating client keys'
+cd ../client
+openssl genrsa -out key.pem 4096
+openssl req -new -key key.pem -out req.pem -outform PEM \
+    -subj "/CN=${serviceHost}/O=client/" -nodes
+
+cd ../ca
+openssl ca -config openssl.cnf -in ../client/req.pem -out \
+    ../client/cert.pem -notext -batch -extensions client_ca_extensions
+
+echo 'Generating Mongodb keys'
+cat ${containerDataDir}/ssl/server/key.pem ${containerDataDir}/ssl/server/cert.pem > ${containerDataDir}/ssl/mongo_server.pem
+cat ${containerDataDir}/ssl/client/key.pem ${containerDataDir}/ssl/client/cert.pem > ${containerDataDir}/ssl/mongo_client.pem


### PR DESCRIPTION
Closes #23, closes #24.

### Changes
- Complete TODOs in `quit.sh`
  - Kill `pm2` with its built-in `kill` command
  - Send `SIGQUIT` to `supervisord` to shut down its children
  - Wait for `supervisord` to fully shut down
  - Print a colorful success message on completion
- Add `renewssl.sh` to renew self-signed SSL certs
  - Should be used when self-signed certificates expire, which happens every 365 days since generation
  - Revokes existing certs, then does [this part of `init.sh`](https://github.com/PREDICT-DPACC/dpdash/blob/585cb7cba46c2b3cd72432975340d8133dde47d6/singularity/init.sh#L51-L79) again
  - Since output filenames are identical, there is no need for any further action/configuration
  - Add [usage documentation to wiki](https://github.com/PREDICT-DPACC/dpdash/wiki/Renewing-self-signed-SSL-certificates)

### Testing
- [x] Tested both scripts myself
- [x] `renewssl.sh` was already used by Habib on their instance when certs expired
- [x] Rebuilt Singularity image: `/data/predict/dpdash-ben-0625.sif`