### PR TITLE
Bugfix toUpperCase error on table

### DIFF
--- a/views/ViewChart.react.js
+++ b/views/ViewChart.react.js
@@ -10,10 +10,10 @@ const ViewChart = ({ graph }) => {
   const { title, description } = graph
   return (
     <AppLayout
-      title={title.toUpperCase()}
+      title={title?.toUpperCase()}
     >
       <Typography variant='title' gutterBottom>
-        {description.toUpperCase()}
+        {description?.toUpperCase()}
       </Typography>
       <BarGraph graph={graph} />
     </AppLayout>

--- a/views/components/ChartList.jsx
+++ b/views/components/ChartList.jsx
@@ -52,11 +52,11 @@ const ChartList = () => {
                 fullWidth
                 href={routes.chart(_id)}
               >
-                {title}
+                {title?.toUpperCase()}
               </Button>
             </TableCell>
             <TableCell align="center">
-              {description.toUpperCase()}
+              {description?.toUpperCase()}
             </TableCell>
             <TableCell align="center">
               <Button


### PR DESCRIPTION
This fixes a toUpperCase error when Justin is creating a new chart.
<img width="762" alt="image" src="https://user-images.githubusercontent.com/19805355/181093854-5e0ae56e-9957-47bd-8f42-732ae92f45c2.png">
