### PR TITLE
Display y axis values as percentages

### DIFF
--- a/server/abstractors/chartsAbstractor.js
+++ b/server/abstractors/chartsAbstractor.js
@@ -9,35 +9,31 @@ export const legend = (fieldValues) => fieldValues
 
 export const chartVariableColors = (fieldValues) => fieldValues.map(({ fieldLabelValueMap: { color }}) => color)
 
-export const groupTargetValuesByFieldValues = (fieldValues) => fieldValues
-.reduce((currentGroup, nextGroup) => {
-  currentGroup[nextGroup.fieldLabelValueMap.label] = nextGroup.fieldLabelValueMap
-    .targetValues
-      .reduce((currentSites, nextSites) => {
-        currentSites[nextSites.site] = { value: nextSites.value }
-
-        return currentSites
-      }, {})
-
-  return currentGroup
-}, {})
-
-export const chartDataAbstractor = (individualCountsList) => Object
-.values(individualCountsList
-.reduce(function (currentSiteData, nextSiteData) {
-  currentSiteData[nextSiteData.fieldLabel] = currentSiteData[nextSiteData.fieldLabel] || [];
-  currentSiteData[nextSiteData.fieldLabel].push(nextSiteData);
+export const chartDataAbstractor = (individualCountsList, fieldValues) => Object
+  .values(individualCountsList
+  .reduce(function (currentSiteData, nextSiteData) {
+    currentSiteData[nextSiteData.fieldLabel] = currentSiteData[nextSiteData.fieldLabel] || [];
+    currentSiteData[nextSiteData.fieldLabel].push(nextSiteData);
 
   return currentSiteData;
-}, {}))
-.map((groupedCounts) => 
-  Object
-  .values(groupedCounts
+  }, {}))
+  .map((groupedCounts) => 
+    Object
+    .values(groupedCounts
     .reduce((currentSite, nextSite) => {
       currentSite[nextSite.siteName] = currentSite[nextSite.siteName]
-      ? { ...nextSite, count: nextSite.count + currentSite[nextSite.siteName].count }
-      : nextSite;
+      ? { 
+          ...nextSite, 
+          count: nextSite.count + currentSite[nextSite.siteName].count, 
+          current: nextSite.count + currentSite[nextSite.siteName].count,  
+          target: nextSite.target ?? fieldValues
+            .find(({fieldLabelValueMap}) => fieldLabelValueMap.label === nextSite.fieldLabel)
+            .fieldLabelValueMap.targetValues
+            .find(({site}) => site === nextSite.siteName).value 
+          }
+      : nextSite
 
       return currentSite;
     }, {}))
-)
+  )
+

--- a/server/controllers/chartsController.js
+++ b/server/controllers/chartsController.js
@@ -45,6 +45,6 @@ export const graphDataController = async (dataDb, userAccess, chart_id) => {
 }
 
 export const fieldValuesController = async(dataDb, chart_id) => await dataDb
-.collection(collections.charts)
-.aggregate(legendQuery(chart_id))
-.toArray()
+  .collection(collections.charts)
+  .aggregate(legendQuery(chart_id))
+  .toArray()

--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -12,8 +12,7 @@ import viewChartPage from '../templates/ViewChart.template';
 import { 
   legend, 
   chartVariableColors,
-  groupTargetValuesByFieldValues,
-  chartDataAbstractor
+  chartDataAbstractor,
 } from '../abstractors/chartsAbstractor'
 import { 
   fieldValuesController,
@@ -61,14 +60,14 @@ router.route('/charts/:chart_id')
       } = await graphDataController(dataDb, userAccess, chart_id)
       const fieldValues = await fieldValuesController(dataDb, chart_id)
       const user = userFromRequest(req)
+      const data = chartDataAbstractor(individualCountsList, fieldValues)
       const graph = { 
         chart_id, 
-        data: chartDataAbstractor(individualCountsList), 
+        data,
         title: chartTitle, 
         description: chartDescription,
         legend: legend(fieldValues),
         chartVariableColors: chartVariableColors(fieldValues),
-        targetValuesMap: groupTargetValuesByFieldValues(fieldValues)
       }
 
       return res.status(200).send(viewChartPage(user, graph))

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -13,7 +13,18 @@ import {
 import { graphStyles } from '../../styles/chart_styles';
 
 const BarGraph = ({ graph }) => {
-  const { targetValuesMap } = graph
+  const transformDataToPercentage = (dataset) => {
+    const totals = dataset[0]?.map((data, i) => {
+      return dataset.reduce((memo, curr) => {
+        return memo + curr[i].count;
+      }, 0);
+    }) || [];
+    return dataset.map((data) => {
+      return data.map((datum, i) => {
+        return { siteName: datum.siteName, count: (datum.count / totals[i]) * 100, fieldLabel: datum.fieldLabel, current: datum.current, target: datum.target };
+      });
+    });
+  }
 
   return(
     <VictoryChart
@@ -37,15 +48,16 @@ const BarGraph = ({ graph }) => {
         label='Total(%)'
         dependentAxis
         style={graphStyles.yAxis}
+        tickFormat={(tick) => `${tick}%`}
       />
       <VictoryStack colorScale={graph.chartVariableColors}>
-        {graph.data.map((data, idx) => (
+        {transformDataToPercentage(graph.data).map((data, idx) => (
           <VictoryBar 
             data={data}
             x='siteName'
             y='count' 
             key={idx}
-            labels={({ datum: { count, fieldLabel, siteName } }) => `Current: ${count} \n Target: ${targetValuesMap[fieldLabel][siteName]?.value || 'N/A'}`}
+            labels={({ datum: { siteName, current, target, fieldLabel }}) => `Site: ${siteName} \n Value: ${fieldLabel} \n Current: ${current} \n Target: ${target}` } 
             labelComponent={
               <VictoryTooltip 
                 constrainToVisibleArea 

--- a/views/styles/chart_styles.js
+++ b/views/styles/chart_styles.js
@@ -1,4 +1,4 @@
-import { neutral_blue } from "../constants/styles"
+import { neutral_blue } from '../constants/styles'
 
 export const chartStyles = (theme) => ({
   textInput: {
@@ -78,12 +78,12 @@ export const chartStyles = (theme) => ({
 export const graphStyles = {
   yAxis: {
     axisLabel: {
-      padding: 35
+      padding: 50
     },
   },
   xAxis: {
     axisLabel: {
-      padding: 35
+      padding: 30
     }
   }
 }


### PR DESCRIPTION
This pr adds a function to the ui that converts the incoming graph data into percentages and that is used to display the y axis percentage values as per Victory. 

The function converts the data that is used to plot the graph, therefore the data object has been expanded to take a current and target property that are used to display the current and target value from the tooltip. This means that groupTargetValuesByFieldValues function was no longer needed and was removed.

Some styling to the graph was added and format fixes from double quotes to single.

<img width="1440" alt="Screen Shot 2022-07-27 at 11 02 34 AM" src="https://user-images.githubusercontent.com/19805355/181295012-0ca6984b-44cd-450c-b629-709af85e1a5e.png">
