### PR TITLE
Duplicate Charts

### DIFF
--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -162,7 +162,7 @@ router
       return res.status(500).json({ message: error.message })
     }
   })
-  .put(ensureAuthenticated, async (req, res) => {
+  .patch(ensureAuthenticated, async (req, res) => {
     try {
       const { dataDb } = req.app.locals
       const { chart_id } = req.params
@@ -189,7 +189,7 @@ router
       return res.status(500).json({ message: error.message })
     }
   })
-  .patch(ensureAuthenticated, async (req, res) => {
+  .put(ensureAuthenticated, async (req, res) => {
     try {
       const { dataDb } = req.app.locals
       const { chart_id } = req.params

--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -162,7 +162,7 @@ router
       return res.status(500).json({ message: error.message })
     }
   })
-  .patch(ensureAuthenticated, async (req, res) => {
+  .put(ensureAuthenticated, async (req, res) => {
     try {
       const { dataDb } = req.app.locals
       const { chart_id } = req.params
@@ -189,10 +189,12 @@ router
       return res.status(500).json({ message: error.message })
     }
   })
-  .put(ensureAuthenticated, async (req, res) => {
+router
+  .route('/api/v1/charts/duplicate')
+  .post(ensureAuthenticated, async (req, res) => {
     try {
       const { dataDb } = req.app.locals
-      const { chart_id } = req.params
+      const { chart_id } = req.body
       const sourceChart = await dataDb.collection(collections.charts).findOne(
         {
           _id: new ObjectID(chart_id),
@@ -206,11 +208,9 @@ router
           title: sourceChart.title + ' Duplicate',
         })
 
-      if (insertedId) return res.status(200).json({ data: insertedId })
-      return res.status(404).json({ message: 'Chart was not duplicated' })
+      return res.status(200).json({ data: insertedId })
     } catch (error) {
-      return res.status(500).json({ message: error.message })
+      return res.status(404).json({ message: 'Chart was not duplicated' })
     }
   })
-
 export default router

--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -189,4 +189,28 @@ router
       return res.status(500).json({ message: error.message })
     }
   })
+  .patch(ensureAuthenticated, async (req, res) => {
+    try {
+      const { dataDb } = req.app.locals
+      const { chart_id } = req.params
+      const sourceChart = await dataDb.collection(collections.charts).findOne(
+        {
+          _id: new ObjectID(chart_id),
+        },
+        { projection: { _id: 0 } }
+      )
+      const { insertedId } = await dataDb
+        .collection(collections.charts)
+        .insertOne({
+          ...sourceChart,
+          title: sourceChart.title + ' Duplicate',
+        })
+
+      if (insertedId) return res.status(200).json({ data: insertedId })
+      return res.status(404).json({ message: 'Chart was not duplicated' })
+    } catch (error) {
+      return res.status(500).json({ message: error.message })
+    }
+  })
+
 export default router

--- a/views/components/ChartList.jsx
+++ b/views/components/ChartList.jsx
@@ -31,9 +31,7 @@ const ChartList = () => {
           setChartList(data)
         })
       }
-    } catch (error) {
-      console.error(error, '*****')
-    }
+    } catch (error) {}
   }
   const onDuplicateChart = async (id) => {
     try {

--- a/views/components/ChartList.jsx
+++ b/views/components/ChartList.jsx
@@ -9,8 +9,9 @@ import Button from '@material-ui/core/Button'
 import Link from '@material-ui/core/Link'
 import Delete from '@material-ui/icons/Delete'
 import Edit from '@material-ui/icons/Edit'
+import PlaylistAdd from '@material-ui/icons/PlaylistAdd'
 
-import { getCharts, deleteChart } from '../fe-utils/fetchUtil'
+import { getCharts, deleteChart, duplicateChart } from '../fe-utils/fetchUtil'
 
 import { routes } from '../routes/routes'
 
@@ -34,6 +35,18 @@ const ChartList = () => {
       console.error(error, '*****')
     }
   }
+  const toDuplicate = async (id) => {
+    try {
+      const duplicated = await duplicateChart(id)
+      if (duplicated?.data) {
+        await getCharts().then(({ data }) => {
+          setChartList(data)
+        })
+      }
+    } catch (error) {
+      console.error(error, '*****')
+    }
+  }
 
   return (
     <Table>
@@ -41,6 +54,7 @@ const ChartList = () => {
         <TableRow>
           <TableCell align='center'>Title</TableCell>
           <TableCell align='center'>Description</TableCell>
+          <TableCell align='center'>Duplicate</TableCell>
           <TableCell align='center'>Edit</TableCell>
           <TableCell align='center'>Delete</TableCell>
         </TableRow>
@@ -54,6 +68,15 @@ const ChartList = () => {
               </Link>
             </TableCell>
             <TableCell align='center'>{description?.toUpperCase()}</TableCell>
+            <TableCell align='center'>
+              <Button
+                type='button'
+                variant='text'
+                onClick={() => toDuplicate(_id)}
+              >
+                <PlaylistAdd />
+              </Button>
+            </TableCell>
             <TableCell align='center'>
               <Link href={routes.editChart(_id)} color='textPrimary'>
                 <Edit />

--- a/views/components/ChartList.jsx
+++ b/views/components/ChartList.jsx
@@ -35,7 +35,7 @@ const ChartList = () => {
       console.error(error, '*****')
     }
   }
-  const toDuplicate = async (id) => {
+  const onDuplicateChart = async (id) => {
     try {
       const duplicated = await duplicateChart(id)
       if (duplicated?.data) {
@@ -72,7 +72,7 @@ const ChartList = () => {
               <Button
                 type='button'
                 variant='text'
-                onClick={() => toDuplicate(_id)}
+                onClick={() => onDuplicateChart(_id)}
               >
                 <PlaylistAdd />
               </Button>

--- a/views/fe-utils/fetchUtil.js
+++ b/views/fe-utils/fetchUtil.js
@@ -135,7 +135,7 @@ const deleteChart = async (id) => {
 const editChart = async (id, formValues) => {
   const res = await window.fetch(apiRoutes.chart(id), {
     ...defaultApiOptions,
-    method: 'PUT',
+    method: 'PATCH',
     body: JSON.stringify(formValues),
   })
 
@@ -158,7 +158,7 @@ const getChart = async (id) => {
 const duplicateChart = async (id) => {
   const res = await window.fetch(apiRoutes.chart(id), {
     ...defaultApiOptions,
-    method: 'PATCH',
+    method: 'PUT',
   })
   if (res.status !== 200) return new Error(res.message)
 

--- a/views/fe-utils/fetchUtil.js
+++ b/views/fe-utils/fetchUtil.js
@@ -155,6 +155,16 @@ const getChart = async (id) => {
   return res.json()
 }
 
+const duplicateChart = async (id) => {
+  const res = await window.fetch(apiRoutes.chart(id), {
+    ...defaultApiOptions,
+    method: 'PATCH',
+  })
+  if (res.status !== 200) return new Error(res.message)
+
+  return res.json()
+}
+
 export {
   fetchStudies,
   fetchStudiesAdmin,
@@ -169,4 +179,5 @@ export {
   deleteChart,
   editChart,
   getChart,
+  duplicateChart,
 }

--- a/views/fe-utils/fetchUtil.js
+++ b/views/fe-utils/fetchUtil.js
@@ -155,10 +155,11 @@ const getChart = async (id) => {
   return res.json()
 }
 
-const duplicateChart = async (id) => {
-  const res = await window.fetch(apiRoutes.chart(id), {
+const duplicateChart = async (chart_id) => {
+  const res = await window.fetch(apiRoutes.chartDuplicate, {
     ...defaultApiOptions,
-    method: 'PUT',
+    method: 'POST',
+    body: JSON.stringify({ chart_id }),
   })
   if (res.status !== 200) return new Error(res.message)
 

--- a/views/routes/routes.js
+++ b/views/routes/routes.js
@@ -22,6 +22,7 @@ export const routes = {
 export const apiRoutes = {
   chart: (chart_id) => `${apiPath}/charts/${chart_id}`,
   charts: `${apiPath}/charts`,
+  chartDuplicate: `${apiPath}/charts/duplicate`,
   subjects: (studies) => `${apiPath}/subjects?q=${JSON.stringify(studies)}`,
   studyDetail: (study_id) => `${apiPath}/study-details/${study_id}`,
   studyDetails: `${apiPath}/study-details`,


### PR DESCRIPTION
Server:
* Patch routes takes a chart_id param and it is used to query a source
  chart
* insert elements of the source chart and edit the title to specify that
  the chart has been duplicated
* Handle error if there's an issue duplicating the chart
UI:
* toDuplicate function could use a better name but duplicateChart is
  already being used as the api call function
* Successful api call refreshes chart list

