### PR TITLE
130 allow users to share charts

### DIFF
--- a/views/Chart.react.js
+++ b/views/Chart.react.js
@@ -1,16 +1,108 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { connect } from 'react-redux'
+import { compose } from 'redux'
+import { withStyles } from '@material-ui/core/styles'
 
+import { chartStyles } from './styles/chart_styles'
 import AppLayout from './layouts/AppLayout'
 import ChartList from './components/ChartList'
 import AddNewChart from './components/Graphs/AddNewChart'
+import ShareChart from './components/ShareCharts'
+import {
+  getCharts,
+  deleteChart,
+  duplicateChart,
+  fetchUsernames,
+  shareChart,
+} from './fe-utils/fetchUtil'
 
-const Charts = () => {
+const NULL_CHART = {}
+
+const Charts = ({ user, classes }) => {
+  const [chartToShare, setChartToShare] = useState(NULL_CHART)
+  const [chartList, setChartList] = useState([])
+  const [usernames, setUsernames] = useState([])
+
+  const closeDialog = () => setChartToShare(NULL_CHART)
+  const handleShareChart = (chart) => setChartToShare(chart)
+  const shareWithUsers = async (chart_id, sharedWith, options = {}) => {
+    const {
+      data: { ok },
+    } = await shareChart(chart_id, sharedWith)
+
+    if (ok === 1) {
+      const updatedChart = { ...chartToShare, sharedWith }
+      const updatedChartList = chartList.map((chart) => {
+        return chart._id === updatedChart._id ? updatedChart : chart
+      })
+
+      setChartList(updatedChartList)
+      options.closeDialog ? closeDialog() : setChartToShare(updatedChart)
+    }
+  }
+  const removeChart = async (id) => {
+    const deleted = await deleteChart(id)
+
+    if (deleted.data > 0) {
+      await loadCharts()
+    }
+  }
+  const onDuplicateChart = async (id) => {
+    const { data: duplicateChartId } = await duplicateChart(id)
+
+    if (!!duplicateChartId) {
+      await loadCharts()
+    }
+  }
+  const loadCharts = async () => {
+    const { data: charts } = await getCharts()
+    setChartList(charts)
+  }
+
+  useEffect(() => {
+    loadCharts()
+    fetchUsernames().then((data) => {
+      const apiUsernames = data
+        .filter((username) => username !== user.uid)
+        .map((username) => ({
+          value: username,
+          label: username,
+        }))
+
+      setUsernames(apiUsernames)
+    })
+  }, [])
+
   return (
     <AppLayout title='Charts'>
-      <ChartList />
+      <ChartList
+        handleShareChart={handleShareChart}
+        chartList={chartList}
+        removeChart={removeChart}
+        onDuplicateChart={onDuplicateChart}
+      />
+      {!!chartToShare._id && (
+        <ShareChart
+          chart={chartToShare}
+          usernames={usernames}
+          handleChange={shareWithUsers}
+          handleClose={closeDialog}
+          classes={classes}
+        />
+      )}
       <AddNewChart />
     </AppLayout>
   )
 }
 
-export default Charts
+const styles = (theme) => ({
+  ...chartStyles(theme),
+})
+const mapStateToProps = (state) => ({
+  user: state.user,
+})
+
+export default compose(
+  withStyles(styles, { withTheme: true }),
+  connect(mapStateToProps)
+)(Charts)

--- a/views/components/ChartList.jsx
+++ b/views/components/ChartList.jsx
@@ -9,90 +9,78 @@ import Button from '@material-ui/core/Button'
 import Link from '@material-ui/core/Link'
 import Delete from '@material-ui/icons/Delete'
 import Edit from '@material-ui/icons/Edit'
+import Share from '@material-ui/icons/Share'
 import PlaylistAdd from '@material-ui/icons/PlaylistAdd'
-
-import { getCharts, deleteChart, duplicateChart } from '../fe-utils/fetchUtil'
 
 import { routes } from '../routes/routes'
 
-const ChartList = () => {
-  const [chartList, setChartList] = useState([])
-
-  useEffect(() => {
-    getCharts().then((res) => setChartList(res.data))
-  }, [])
-
-  const removeChart = async (id) => {
-    try {
-      const deleted = await deleteChart(id)
-
-      if (deleted.data > 0) {
-        await getCharts().then(({ data }) => {
-          setChartList(data)
-        })
-      }
-    } catch (error) {}
-  }
-  const onDuplicateChart = async (id) => {
-    try {
-      const duplicated = await duplicateChart(id)
-      if (duplicated?.data) {
-        await getCharts().then(({ data }) => {
-          setChartList(data)
-        })
-      }
-    } catch (error) {
-      console.error(error, '*****')
-    }
-  }
-
+const ChartList = ({
+  handleShareChart,
+  chartList,
+  removeChart,
+  onDuplicateChart,
+}) => {
   return (
-    <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell align='center'>Title</TableCell>
-          <TableCell align='center'>Description</TableCell>
-          <TableCell align='center'>Duplicate</TableCell>
-          <TableCell align='center'>Edit</TableCell>
-          <TableCell align='center'>Delete</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {chartList.map(({ title, description, _id }) => (
-          <TableRow key={_id}>
-            <TableCell align='center'>
-              <Link color='textPrimary' href={routes.chart(_id)}>
-                {title?.toUpperCase()}
-              </Link>
-            </TableCell>
-            <TableCell align='center'>{description?.toUpperCase()}</TableCell>
-            <TableCell align='center'>
-              <Button
-                type='button'
-                variant='text'
-                onClick={() => onDuplicateChart(_id)}
-              >
-                <PlaylistAdd />
-              </Button>
-            </TableCell>
-            <TableCell align='center'>
-              <Link href={routes.editChart(_id)} color='textPrimary'>
-                <Edit />
-              </Link>
-            </TableCell>
-            <TableCell align='center'>
-              <Button
-                type='button'
-                variant='text'
-                onClick={() => removeChart(_id)}
-              >
-                <Delete />
-              </Button>
-            </TableCell>
+    <>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell align='center'>Title</TableCell>
+            <TableCell align='center'>Description</TableCell>
+            <TableCell align='center'>Duplicate</TableCell>
+            <TableCell align='center'>Edit</TableCell>
+            <TableCell align='center'>Share</TableCell>
+            <TableCell align='center'>Delete</TableCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHead>
+        <TableBody>
+          {chartList.map((chart) => (
+            <TableRow key={chart._id}>
+              <TableCell align='center'>
+                <Link color='textPrimary' href={routes.chart(chart._id)}>
+                  {chart.title?.toUpperCase()}
+                </Link>
+              </TableCell>
+              <TableCell align='center'>
+                {chart.description?.toUpperCase()}
+              </TableCell>
+              <TableCell align='center'>
+                <Button
+                  type='button'
+                  variant='text'
+                  onClick={() => onDuplicateChart(chart._id)}
+                >
+                  <PlaylistAdd />
+                </Button>
+              </TableCell>
+              <TableCell align='center'>
+                <Link href={routes.editChart(chart._id)} color='textPrimary'>
+                  <Edit />
+                </Link>
+              </TableCell>
+              <TableCell align='center'>
+                <Button
+                  type='button'
+                  variant='text'
+                  onClick={() => handleShareChart(chart)}
+                >
+                  <Share />
+                </Button>
+              </TableCell>
+              <TableCell align='center'>
+                <Button
+                  type='button'
+                  variant='text'
+                  onClick={() => removeChart(chart._id)}
+                >
+                  <Delete />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
   )
 }
 

--- a/views/components/ShareCharts.jsx
+++ b/views/components/ShareCharts.jsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import Select from '@material-ui/core/Select'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import Chip from '@material-ui/core/Chip'
+import MenuItem from '@material-ui/core/MenuItem'
+import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import Input from '@material-ui/core/Input'
+
+const menuProps = {
+  PaperProps: {
+    style: {
+      marginTop: '50px',
+    },
+  },
+}
+
+const ShareChart = ({
+  chart,
+  usernames,
+  handleChange,
+  handleClose,
+  classes,
+}) => {
+  const [sharedWith, setSharedWith] = React.useState(chart.sharedWith || [])
+
+  return (
+    <Dialog open onClose={handleClose} fullScreen={true}>
+      <DialogTitle
+        id='alert-dialog-title'
+        disableTypography={true}
+        className={classes.dialogTitle}
+      >
+        <Typography variant='title' className={classes.dialogTypography}>
+          Share your chart
+        </Typography>
+      </DialogTitle>
+      <DialogContent className={classes.dialogContent}>
+        <Select
+          multiple
+          value={sharedWith}
+          onChange={(event) => setSharedWith(event.target.value)}
+          input={<Input id='select-multiple' />}
+          MenuProps={menuProps}
+          fullWidth
+          renderValue={(selected) => (
+            <>
+              {selected.map((value) => (
+                <Chip
+                  key={value}
+                  label={value}
+                  onDelete={() => {
+                    const updatedSharedWith = sharedWith.filter(
+                      (username) => username !== value
+                    )
+                    setSharedWith(updatedSharedWith)
+
+                    if (
+                      chart.sharedWith.find((username) => username === value)
+                    ) {
+                      return handleChange(chart, updatedSharedWith, {
+                        closeDialog: false,
+                      })
+                    }
+                  }}
+                  onMouseDown={(event) => {
+                    event.stopPropagation()
+                  }}
+                />
+              ))}
+            </>
+          )}
+        >
+          {usernames.map(({ value, label }) => (
+            <MenuItem key={value} value={value}>
+              {label}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} className={classes.dialogCancelButton}>
+          Cancel
+        </Button>
+        <Button
+          variant='outlined'
+          className={classes.dialogShareButton}
+          onClick={() =>
+            handleChange(chart._id, sharedWith, { closeDialog: true })
+          }
+        >
+          Submit
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ShareChart

--- a/views/constants/styles.js
+++ b/views/constants/styles.js
@@ -2,4 +2,6 @@ export const colors = {
   dark_sky_blue: '#97C0CE',
   neutral_blue: '#5790BD',
   anti_flash_white: '#EDEFFA',
+  white: '#ffffff',
+  black: 'rgba(0,0,0,0.7)',
 }

--- a/views/fe-utils/fetchUtil.js
+++ b/views/fe-utils/fetchUtil.js
@@ -169,7 +169,7 @@ const duplicateChart = async (chart_id) => {
 
 const fetchConfigurations = async (uid) => {
   const res = await window.fetch(apiRoutes.configs(uid), {
-    defaultApiOptions,
+    ...defaultApiOptions,
     method: 'GET',
   })
 
@@ -180,10 +180,21 @@ const fetchConfigurations = async (uid) => {
 
 const fetchPreferences = async (uid) => {
   const res = await window.fetch(apiRoutes.preferences(uid), {
-    defaultApiOptions,
+    ...defaultApiOptions,
     method: 'GET',
   })
 
+  if (res.status !== 200) return new Error(res.message)
+
+  return res.json()
+}
+
+const shareChart = async (chart_id, sharedWith) => {
+  const res = await window.fetch(apiRoutes.shareChart(chart_id), {
+    ...defaultApiOptions,
+    method: 'POST',
+    body: JSON.stringify({ sharedWith }),
+  })
   if (res.status !== 200) return new Error(res.message)
 
   return res.json()
@@ -206,4 +217,5 @@ export {
   duplicateChart,
   fetchConfigurations,
   fetchPreferences,
+  shareChart,
 }

--- a/views/routes/routes.js
+++ b/views/routes/routes.js
@@ -31,6 +31,7 @@ export const apiRoutes = {
   preferences: (uid) => `${apiPath}/users/${uid}/preferences`,
   searchStudies: `${apiPath}/search/studies`,
   subject: `${apiPath}/subjects`,
+  shareChart: (chart_id) => `${apiPath}/charts/${chart_id}/share`,
 }
 
 export const defaultApiOptions = {

--- a/views/styles/chart_styles.js
+++ b/views/styles/chart_styles.js
@@ -73,6 +73,26 @@ export const chartStyles = (theme) => ({
     alignSelf: 'flex-end',
     paddingRight: '2%',
   },
+  dialogTitle: {
+    backgroundColor: colors.black,
+  },
+  dialogTypography: {
+    color: colors.white,
+  },
+  dialogContent: {
+    padding: '24px',
+    overflowY: 'visible',
+  },
+  dialogCancelButton: {
+    color: colors.neutral_blue,
+  },
+  dialogShareButton: {
+    borderColor: colors.neutral_blue,
+    paddingTop: '11px',
+    color: colors.white,
+    backgroundColor: colors.neutral_blue,
+    marginLeft: '12px',
+  },
 })
 
 export const graphStyles = {


### PR DESCRIPTION
Allow users to share charts

FE
* Added a component that renders a list of users and displays users that the chart as been shared with
* Remove and update users from the sharedWith list 
* New api route that updates the sharedWith list
* Connected redux to charts component
* Refresh charts list from a successful update

BE
* Updated query to handle owned and sharedWith charts
* Added new route to update sharedWith list

[Video of functionality](https://drive.google.com/file/d/1OWm0MwNNaLRgULY3loJAMyo1PffJl6-V/view?usp=sharing)

<img width="520" alt="Screen Shot 2022-08-15 at 5 16 24 PM" src="https://user-images.githubusercontent.com/19805355/184730636-1d3ad4cd-784b-4704-86bc-aee71eaa7668.png">
<img width="514" alt="Screen Shot 2022-08-15 at 5 16 42 PM" src="https://user-images.githubusercontent.com/19805355/184730652-11b1c453-6d59-45c8-a833-5d7e5ccc4d3b.png">
<img width="1439" alt="Screen Shot 2022-08-15 at 5 38 12 PM" src="https://user-images.githubusercontent.com/19805355/184733284-58c74eda-5db9-4de3-b3db-86e062c1e20d.png">

