### PR TITLE
140 add a public checkmark when creating editing a chart

### DIFF
--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -98,8 +98,14 @@ router
   .route('/api/v1/charts')
   .post(ensureAuthenticated, async (req, res) => {
     try {
-      const { fieldLabelValueMap, title, variable, assessment, description } =
-        req.body
+      const {
+        fieldLabelValueMap,
+        title,
+        variable,
+        assessment,
+        description,
+        public: isPublic,
+      } = req.body
       const { dataDb } = req.app.locals
       const { insertedId } = await dataDb
         .collection(collections.charts)
@@ -109,6 +115,7 @@ router
           assessment,
           description,
           fieldLabelValueMap,
+          public: isPublic,
           owner: req.user,
         })
 
@@ -124,7 +131,13 @@ router
       const { dataDb } = req.app.locals
       const chartList = await dataDb
         .collection(collections.charts)
-        .find({ $or: [{ owner: req.user }, { sharedWith: req.user }] })
+        .find({
+          $or: [
+            { owner: req.user },
+            { sharedWith: req.user },
+            { public: true },
+          ],
+        })
         .toArray()
       return res.status(200).json({ data: chartList })
     } catch (error) {
@@ -178,8 +191,14 @@ router
     try {
       const { dataDb } = req.app.locals
       const { chart_id } = req.params
-      const { title, variable, assessment, description, fieldLabelValueMap } =
-        req.body
+      const {
+        title,
+        variable,
+        assessment,
+        description,
+        fieldLabelValueMap,
+        public: isPublic,
+      } = req.body
       const { result } = await dataDb.collection(collections.charts).updateOne(
         { _id: new ObjectID(chart_id) },
         {
@@ -189,6 +208,7 @@ router
             assessment,
             description,
             fieldLabelValueMap,
+            public: isPublic,
             updatedAt: new Date().toISOString(),
           },
         }

--- a/views/NewChart.react.js
+++ b/views/NewChart.react.js
@@ -26,17 +26,14 @@ const initialValues = (user) => ({
       targetValues: targetValuesFields(user.userAccess),
     },
   ],
+  public: false,
 })
 
 const NewChart = ({ classes, user }) => {
   const handleSubmit = async (e, formValues) => {
-    try {
-      e.preventDefault()
-      const { data } = await createChart(formValues)
-      window.location.assign(routes.chart(data.chart_id))
-    } catch (error) {
-      console.error(error)
-    }
+    e.preventDefault()
+    const { data } = await createChart(formValues)
+    window.location.assign(routes.chart(data.chart_id))
   }
 
   return (

--- a/views/forms/BarChartFields.jsx
+++ b/views/forms/BarChartFields.jsx
@@ -4,6 +4,8 @@ import TextField from '@material-ui/core/TextField'
 import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
 import ColorPicker from '../components/ColorPicker'
+import Checkbox from '@material-ui/core/Checkbox'
+import InputLabel from '@material-ui/core/InputLabel'
 
 import { colors } from '../../constants/styles'
 
@@ -11,7 +13,11 @@ import { targetValuesFields } from '../fe-utils/targetValuesUtil'
 
 const BarChartFields = ({ classes, formValues, setFormValues, studies }) => {
   const updateFormValues = (e) =>
-    setFormValues({ ...formValues, [e.target.name]: e.target.value })
+    setFormValues({
+      ...formValues,
+      [e.target.name]:
+        e.target.type !== 'checkbox' ? e.target.value : e.target.checked,
+    })
   const addValueAndLabelField = () =>
     setFormValues((prevState) => ({
       ...prevState,
@@ -94,7 +100,17 @@ const BarChartFields = ({ classes, formValues, setFormValues, studies }) => {
         fullWidth
       />
       <div className={classes.formLabelRow}>
-        <br />
+        <InputLabel htmlFor='public_checkbox' className={classes.publicText}>
+          Public
+        </InputLabel>
+        <Checkbox
+          checked={formValues.public}
+          onChange={updateFormValues}
+          name='public'
+          color='default'
+          id='public_checkbox'
+          aria-label
+        />
       </div>
       {formValues.fieldLabelValueMap.map((field, idx) => (
         <>

--- a/views/styles/chart_styles.js
+++ b/views/styles/chart_styles.js
@@ -97,6 +97,9 @@ export const chartStyles = (theme) => ({
     pointerEvents: 'none',
     color: colors.disabled_gray,
   },
+  publicText: {
+    alignSelf: 'center',
+  },
 })
 
 export const graphStyles = {


### PR DESCRIPTION
Adds a checkbox to chart to set chart as publicly available across all users

public is a reserved keyword for node in the charts file it will look like `public: isPublic` this is to set the incoming req.body public value as isPublic variable and then it is stored in the db as public.

<img width="1025" alt="Screen Shot 2022-08-23 at 11 43 14 AM" src="https://user-images.githubusercontent.com/19805355/186214820-bbe15c26-f001-4ca5-9c62-9198d3f0d6d5.png">
