### PR TITLE
Remove totals study export

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -1,1 +1,0 @@
-export const TOTALS_STUDY = 'Totals'

--- a/server/controllers/chartsController.js
+++ b/server/controllers/chartsController.js
@@ -1,8 +1,8 @@
 import { ObjectID } from 'mongodb'
 
 import { collections } from '../utils/mongoCollections'
-import { TOTALS_STUDY } from '../../constants'
 
+const TOTALS_STUDY = 'Totals'
 const studyCountsToPercentage = (studyCount, targetTotal) =>
   (100 * +studyCount) / targetTotal
 

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -12,7 +12,8 @@ import {
 
 import { graphStyles } from '../../styles/chart_styles'
 import { colors } from '../../../constants/styles'
-import { TOTALS_STUDY } from '../../../constants'
+
+const TOTALS_STUDY = 'Totals'
 
 const BarGraph = ({ graph }) => {
   return (


### PR DESCRIPTION
When running on staging we got the following error. I believe the error could be caused by importing the constant on the front-end and back-end, but I'm not sure about that and want to try to get a fix out ASAP due to meetings today.

```
/sw/apps/dpdash/constants/index.js:1
export const TOTALS_STUDY = 'Totals'
^^^^^^

SyntaxError: Unexpected token 'export'
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1025:15)
    at Module._compile (node:internal/modules/cjs/loader:1059:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at Module.Hook._require.Module.require (/sw/apps/dpdash/node_modules/require-in-the-middle/index.js:80:39)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (/sw/apps/dpdash/dist/controllers/chartsController.js:24:18)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at Module.Hook._require.Module.require (/sw/apps/dpdash/node_modules/require-in-the-middle/index.js:80:39)
```