### PR TITLE
Update the owner and shared users when duplicating

### DIFF
--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -238,7 +238,8 @@ router
         .collection(collections.charts)
         .insertOne({
           ...sourceChart,
-          title: sourceChart.title + ' Duplicate',
+          owner: req.user,
+          sharedWith: [],
         })
 
       return res.status(200).json({ data: insertedId })


### PR DESCRIPTION
This commit:

* Sets the owner to the current user when duplicating a chart.
* Re-sets the shared users to an empty string when duplicating a chart.
* Does not change the chart title when duplicating per client request.

Why?

Only the owner can edit charts and it defeats the purpose of duplicating
a chart if the user still can't edit them after duplicating.