### PR TITLE
Fix horizontal scroll

### DIFF
--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -7,8 +7,8 @@ import {
   VictoryStack,
   VictoryLegend,
   VictoryLabel,
-  VictoryVoronoiContainer,
   VictoryTooltip,
+  VictoryZoomContainer,
 } from 'victory'
 
 import { colors } from '../../../constants/styles'
@@ -17,41 +17,25 @@ import { toolTipPercent } from '../../fe-utils/tooltipUtil'
 
 const NOT_AVAILABLE = 'N/A'
 const TOTALS_STUDY = 'Totals'
+const DEFAULT_ZOOM = 6
+
 
 const BarGraph = ({ graph }) => {
+  const siteDataPerChartValue = Object.values(graph.data)
+  const numSitesPerValue = siteDataPerChartValue.map((value) => value.length)
+  const numSites = Math.max(...numSitesPerValue)
+  const initialZoom = Math.min(numSites, DEFAULT_ZOOM)
+
   return (
     <VictoryChart
-      domainPadding={20}
-      domain={{ x: [0, 6] }}
+      domainPadding={10}
+      domain={{ x: [0, numSites], y: [0, 100] }}
       theme={VictoryTheme.material}
       containerComponent={
-        <VictoryVoronoiContainer
-          labels={({ datum: { study, studyTarget, count, valueLabel } }) => {
-            if (graph.studyTotals[study]) {
-              const { targetTotal, count: studyTotalCount } =
-                graph.studyTotals[study]
-              const showToolTip =
-                study &&
-                count &&
-                study !== TOTALS_STUDY &&
-                valueLabel !== NOT_AVAILABLE
-              return showToolTip
-                ? `${study} target: ${targetTotal} (100%)\n${study} current: ${studyTotalCount} (${toolTipPercent(
-                    studyTotalCount,
-                    targetTotal
-                  )}%)\n${valueLabel} target: ${studyTarget} (${toolTipPercent(
-                    studyTarget,
-                    targetTotal
-                  )}%)\n${valueLabel} current: ${count} (${toolTipPercent(
-                    count,
-                    targetTotal
-                  )}%)`
-                : null
-            }
-          }}
-          labelComponent={
-            <VictoryTooltip style={{ fontSize: 7, textAnchor: 'start' }} />
-          }
+        <VictoryZoomContainer
+          allowZoom={false}
+          allowPan={numSites > initialZoom}
+          zoomDomain={{ x: [0, initialZoom + 0.5] }}
         />
       }
     >
@@ -71,12 +55,12 @@ const BarGraph = ({ graph }) => {
         tickFormat={(yAxisValue) => `${yAxisValue}%`}
       />
       <VictoryStack>
-        {Object.values(graph.data).map((data, idx) => (
+        {siteDataPerChartValue.map((data, idx) => (
           <VictoryBar
             data={data}
             x="study"
             y="percent"
-            key={'bar' + idx}
+            key={idx}
             style={{
               data: {
                 fill: ({ datum }) => datum.color,

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -19,8 +19,53 @@ const NOT_AVAILABLE = 'N/A'
 const TOTALS_STUDY = 'Totals'
 const DEFAULT_ZOOM = 6
 
+const tooltipText = (graph, datum) => {
+  const { study, studyTarget, count, valueLabel } = datum
+  if (graph.studyTotals[study]) {
+    const { targetTotal, count: studyTotalCount } = graph.studyTotals[study]
+    const showToolTip =
+      study && count && study !== TOTALS_STUDY && valueLabel !== NOT_AVAILABLE
+    return showToolTip
+      ? `${study} target: ${targetTotal} (100%)\n${study} current: ${studyTotalCount} (${toolTipPercent(
+          studyTotalCount,
+          targetTotal
+        )}%)\n${valueLabel} target: ${studyTarget} (${toolTipPercent(
+          studyTarget,
+          targetTotal
+        )}%)\n${valueLabel} current: ${count} (${toolTipPercent(
+          count,
+          targetTotal
+        )}%)`
+      : null
+  }
+}
+
+const LabelWithTooltip = ({ hoverData, ...props }) => {
+  const isTooltipActive =
+    !!hoverData &&
+    hoverData.group === props.datum._group &&
+    hoverData.stack === props.datum._stack &&
+    hoverData.text
+
+  return (
+    <g>
+      <VictoryLabel
+        {...props}
+        dy={15}
+        style={{ fill: colors.anti_flash_white, fontSize: 7 }}
+      />
+      <VictoryTooltip
+        {...props}
+        text={hoverData?.text}
+        active={isTooltipActive}
+        style={{ fontSize: 7, textAnchor: 'start', padding: 5 }}
+      />
+    </g>
+  )
+}
 
 const BarGraph = ({ graph }) => {
+  const [hoverData, setHoverData] = React.useState()
   const siteDataPerChartValue = Object.values(graph.data)
   const numSitesPerValue = siteDataPerChartValue.map((value) => value.length)
   const numSites = Math.max(...numSitesPerValue)
@@ -43,7 +88,7 @@ const BarGraph = ({ graph }) => {
         orientation="horizontal"
         gutter={20}
         data={graph.legend}
-        x={150}
+        x={125}
         y={20}
         labelComponent={<VictoryLabel />}
       />
@@ -54,7 +99,7 @@ const BarGraph = ({ graph }) => {
         style={graphStyles.yAxis}
         tickFormat={(yAxisValue) => `${yAxisValue}%`}
       />
-      <VictoryStack>
+      <VictoryStack labelComponent={<LabelWithTooltip hoverData={hoverData} />}>
         {siteDataPerChartValue.map((data, idx) => (
           <VictoryBar
             data={data}
@@ -69,13 +114,6 @@ const BarGraph = ({ graph }) => {
             labels={({ datum }) =>
               !!datum?.percent ? `${datum.percent.toFixed(0)}%` : null
             }
-            labelComponent={
-              <VictoryLabel
-                dy={15}
-                labelPlacement="perpendicular"
-                style={{ fill: colors.anti_flash_white, fontSize: 8 }}
-              />
-            }
             events={[
               {
                 target: 'data',
@@ -84,7 +122,14 @@ const BarGraph = ({ graph }) => {
                     return [
                       {
                         mutation: (props) => {
+                          setHoverData({
+                            group: props.datum._group,
+                            stack: props.datum._stack,
+                            text: tooltipText(graph, props.datum),
+                          })
+
                           return {
+                            ...props,
                             style: {
                               ...props.style,
                               stroke: colors.black,
@@ -96,6 +141,7 @@ const BarGraph = ({ graph }) => {
                     ]
                   },
                   onMouseOut: () => {
+                    setHoverData(undefined)
                     return [
                       {
                         mutation: () => {


### PR DESCRIPTION
This PR:

* Replaces the VictoryVoronoiContainer with the VictoryZoomContainer.
We used the VictoryVoronoiContainer to easily render tooltips but that container
does not work well if there are lots of sites. The sites either render on top
of each other or the sites outside the view are cut off. The VictoryZoomContainer
allows horizontal scrolling to display the sites but we need another solution
for rendering tooltips.
* Creates a custom label component, `LabelWithTooltip`. The label
is always rendered, which displays a percentage value within the bar chart
stack element. The tooltip is only rendered when hovering over a stack and
it displays more details about that stack's data.

![horizontal-scroll](https://user-images.githubusercontent.com/2905145/187732194-d23856f3-9d3b-4b1a-b2f5-fb951d13bd81.gif)

![label-and-tooltip](https://user-images.githubusercontent.com/2905145/187730536-0e3c2048-dc68-473c-a0b8-3ce8bb514eff.gif)
