### PR TITLE
Fix "Cannot read property 'map` of undefined" bug

### DIFF
--- a/server/controllers/chartsController.js
+++ b/server/controllers/chartsController.js
@@ -36,9 +36,10 @@ const postProcessData = (data, studyTotals) => {
   })
 
   // need the largest horizontal section so that all sites are accounted for
-  const largestHorizontalSection = Object.values(processedData).sort(
-    (arr1, arr2) => arr2.length - arr1.length
-  )[0]
+  const largestHorizontalSection =
+    Object.values(processedData).sort(
+      (arr1, arr2) => arr2.length - arr1.length
+    )[0] || []
 
   const notAvailableArray = largestHorizontalSection.map((studySection) => {
     const totals = studyTotals[studySection.study]
@@ -54,7 +55,10 @@ const postProcessData = (data, studyTotals) => {
     }
   })
 
-  processedData['N/A'] = notAvailableArray
+  if (notAvailableArray.length) {
+    processedData['N/A'] = notAvailableArray
+  }
+
   Object.keys(processedData).forEach((key) => {
     processedData[key].sort(function (studyA, studyB) {
       if (studyA.study === TOTALS_STUDY) return -1
@@ -62,6 +66,7 @@ const postProcessData = (data, studyTotals) => {
       else return 0
     })
   })
+
   return processedData
 }
 

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -13,6 +13,7 @@ import {
 
 import { colors } from '../../../constants/styles'
 import { graphStyles } from '../../styles/chart_styles'
+import { routes } from '../../routes/routes'
 import { toolTipPercent } from '../../fe-utils/tooltipUtil'
 
 const NOT_AVAILABLE = 'N/A'
@@ -70,6 +71,15 @@ const BarGraph = ({ graph }) => {
   const numSitesPerValue = siteDataPerChartValue.map((value) => value.length)
   const numSites = Math.max(...numSitesPerValue)
   const initialZoom = Math.min(numSites, DEFAULT_ZOOM)
+
+  if (!siteDataPerChartValue.length) {
+    return (
+      <>
+        <p>This chart has no data to display.</p>
+        <a href={routes.editChart(graph.chart_id)}>Edit chart</a>
+      </>
+    )
+  }
 
   return (
     <VictoryChart


### PR DESCRIPTION
This commit fixes a bug in which the user saw the message
"Cannot read property 'map` of undefined" when viewing a chart. This bug
surfaces when the assessment does not exist, causing our `largestHorizontalSection`
to be undefined. To fix this we default that value to an empty array.

This commit also includes the handling of empty data on the front-end with
a link to edit the chart.