### PR TITLE
Ensure all sites have records for all values

### DIFF
--- a/server/controllers/chartsController.js
+++ b/server/controllers/chartsController.js
@@ -59,11 +59,18 @@ const postProcessData = (data, studyTotals) => {
     processedData['N/A'] = notAvailableArray
   }
 
+  // sort all processedData values in alphabetical order
+  // with Totals first
   Object.keys(processedData).forEach((key) => {
     processedData[key].sort(function (studyA, studyB) {
-      if (studyA.study === TOTALS_STUDY) return -1
-      if (studyB.study === TOTALS_STUDY) return 1
-      else return 0
+      if (studyA.study === TOTALS_STUDY) {
+        return -1
+      }
+      if (studyB.study === TOTALS_STUDY) {
+        return 1
+      }
+
+      return studyA.study > studyB.study ? 1 : -1
     })
   })
 
@@ -135,11 +142,10 @@ export const graphDataController = async (dataDb, userAccess, chart_id) => {
       const hasValue = subjectDayData.some(
         (dayData) => dayData[chart.variable] == value
       )
+      const dataKey = `${study}-${label}-${color}-${targetValue}`
+      const totalsDataKey = `${TOTALS_STUDY}-${label}-${color}-undefined`
 
       if (hasValue) {
-        const dataKey = `${study}-${label}-${color}-${targetValue}`
-        const totalsDataKey = `${TOTALS_STUDY}-${label}-${color}-undefined`
-
         if (data[dataKey]) {
           data[dataKey] += 1
         } else {
@@ -152,6 +158,10 @@ export const graphDataController = async (dataDb, userAccess, chart_id) => {
         }
         studyTotals[study].count += 1
         studyTotals[TOTALS_STUDY].count += 1
+      } else {
+        if (!data[dataKey]) {
+          data[dataKey] = 0
+        }
       }
     })
   }

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -138,6 +138,13 @@ const BarGraph = ({ graph }) => {
                             text: tooltipText(graph, props.datum),
                           })
 
+                          if (
+                            props.datum.study === TOTALS_STUDY ||
+                            props.datum.valueLabel === NOT_AVAILABLE
+                          ) {
+                            return props
+                          }
+
                           return {
                             ...props,
                             style: {


### PR DESCRIPTION
This PR:

* Adds data for variables that have a 0 count of subjects so that the
  data arrays are all the same size. This is intended to fix a rendering
  issue on the chart page that seems to be caused from some graphs not
  having sections for every value.
* Alphabetizes the processed data arrays. This ensures that the sections
  for each study have data that corresponds to that section and not another
  study.
* Does not adjust graph style on N/A and totals hover