### PR TITLE
Specify height and width of the chart

### DIFF
--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -86,6 +86,8 @@ const BarGraph = ({ graph }) => {
       domainPadding={10}
       domain={{ x: [0, numSites], y: [0, 100] }}
       theme={VictoryTheme.material}
+      height={400}
+      width={600}
       containerComponent={
         <VictoryZoomContainer
           allowZoom={false}


### PR DESCRIPTION
This commit:

* Specifies the height and width props of the VictoryChart. Since we're
  rendering a responsive chart, these values will be used to set the aspect
  ratio of the chart and not the specific height and width values.


| Before | After |
| ------ | ----- |
| ![Screen Shot 2022-09-02 at 11 25 54 AM](https://user-images.githubusercontent.com/2905145/188182787-b063fb97-3f52-47b5-99d6-3d8a7efd215b.png) | ![Screen Shot 2022-09-02 at 11 25 37 AM](https://user-images.githubusercontent.com/2905145/188182809-90858ca6-46ba-4c2e-9b8f-d5514193cd34.png) |