### PR TITLE
Fix NaN tooltip and undefined method "count" errors

### DIFF
--- a/server/controllers/chartsController.js
+++ b/server/controllers/chartsController.js
@@ -5,8 +5,13 @@ import { collections } from '../utils/mongoCollections'
 const TOTALS_STUDY = 'Totals'
 const STUDIES_TO_OMIT = ['files', 'combined']
 
-const studyCountsToPercentage = (studyCount, targetTotal) =>
-  (100 * +studyCount) / targetTotal
+const studyCountsToPercentage = (studyCount, targetTotal) => {
+  if (!targetTotal || Number.isNaN(+studyCount) || Number.isNaN(+targetTotal)) {
+    return 0
+  }
+
+  return (+studyCount / +targetTotal) * 100
+}
 
 const postProcessData = (data, studyTotals) => {
   const processedData = {}

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -52,7 +52,7 @@ const LabelWithTooltip = ({ hoverData, ...props }) => {
     !!hoverData &&
     hoverData.group === props.datum._group &&
     hoverData.stack === props.datum._stack &&
-    hoverData.text
+    !!hoverData.text
 
   return (
     <g>

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -24,19 +24,25 @@ const tooltipText = (graph, datum) => {
   const { study, studyTarget, count, valueLabel } = datum
   if (graph.studyTotals[study]) {
     const { targetTotal, count: studyTotalCount } = graph.studyTotals[study]
+    const totalCount = targetTotal || studyTotalCount
     const showToolTip =
       study && count && study !== TOTALS_STUDY && valueLabel !== NOT_AVAILABLE
     return showToolTip
-      ? `${study} target: ${targetTotal} (100%)\n${study} current: ${studyTotalCount} (${toolTipPercent(
+      ? `${study} target: ${
+          targetTotal || NOT_AVAILABLE
+        } (100%)\n${study} current: ${
+          studyTotalCount || NOT_AVAILABLE
+        } (${toolTipPercent(
           studyTotalCount,
-          targetTotal
-        )}%)\n${valueLabel} target: ${studyTarget} (${toolTipPercent(
+          totalCount
+        )}%)\n${valueLabel} target: ${
+          studyTarget || NOT_AVAILABLE
+        } (${toolTipPercent(
           studyTarget,
-          targetTotal
-        )}%)\n${valueLabel} current: ${count} (${toolTipPercent(
-          count,
-          targetTotal
-        )}%)`
+          totalCount
+        )}%)\n${valueLabel} current: ${
+          count || NOT_AVAILABLE
+        } (${toolTipPercent(count, totalCount)}%)`
       : null
   }
 }

--- a/views/fe-utils/tooltipUtil.js
+++ b/views/fe-utils/tooltipUtil.js
@@ -1,2 +1,7 @@
-export const toolTipPercent = (count, targetTotal) =>
-  ((+count / +targetTotal) * 100).toFixed(0)
+export const toolTipPercent = (count, targetTotal) => {
+  if (!targetTotal || Number.isNaN(+count) || Number.isNaN(+targetTotal)) {
+    return 0
+  }
+
+  return ((+count / +targetTotal) * 100).toFixed(0)
+}


### PR DESCRIPTION
This PR:

* Updates variable names to remove name collision.
* Updates the study total count if we have one, otherwise creates a new
  study total object. So that we're not calling "count" on undefined.
* Sets the study count percent to 0 instead of NaN if there is no
  count or target.