### PR TITLE
Get the most recent sites when editing a chart

### DIFF
--- a/server/routes/charts.js
+++ b/server/routes/charts.js
@@ -13,6 +13,7 @@ import editChartPage from '../templates/EditChart.template'
 import { legend } from '../helpers/chartsHelpers'
 import { graphDataController } from '../controllers/chartsController'
 import { routes } from '../utils/routes'
+import { defaultTargetValueMap } from '../utils/defaultTargetValueMap'
 
 const router = Router()
 
@@ -193,6 +194,17 @@ router
         )
 
       if (!chart) return res.redirect(routes.charts)
+
+      const { userAccess } = req.session
+      const targetValuesMap = defaultTargetValueMap(userAccess)
+      chart.fieldLabelValueMap = chart.fieldLabelValueMap.map((fieldValue) => {
+        const updateTargetValues = {
+          ...targetValuesMap,
+          ...fieldValue.targetValues,
+        }
+        fieldValue.targetValues = updateTargetValues
+        return fieldValue
+      })
 
       return res.status(200).json({ data: chart })
     } catch (error) {

--- a/server/utils/defaultTargetValueMap.js
+++ b/server/utils/defaultTargetValueMap.js
@@ -1,0 +1,8 @@
+const DISALLOWED_STUDIES = ['combined', 'files']
+const allowedStudies = (study) => !DISALLOWED_STUDIES.includes(study)
+
+export const defaultTargetValueMap = (studyList) =>
+  studyList.filter(allowedStudies).reduce((targets, study) => {
+    targets[study] = ''
+    return targets
+  }, {})

--- a/server/utils/userUpdatedSiteList.js
+++ b/server/utils/userUpdatedSiteList.js
@@ -1,0 +1,8 @@
+const DISALLOWED_STUDIES = ['combined', 'files']
+const allowedStudies = (study) => !DISALLOWED_STUDIES.includes(study)
+
+export const recentStudyList = (studyList) =>
+  studyList.filter(allowedStudies).reduce((targets, study) => {
+    targets[study] = ''
+    return targets
+  }, {})

--- a/views/NewChart.react.js
+++ b/views/NewChart.react.js
@@ -37,7 +37,7 @@ const NewChart = ({ classes, user }) => {
   }
 
   return (
-    <AppLayout title='Create chart'>
+    <AppLayout title="Create chart">
       <ChartForm
         classes={classes}
         handleSubmit={handleSubmit}

--- a/views/forms/BarChartFields.jsx
+++ b/views/forms/BarChartFields.jsx
@@ -8,7 +8,6 @@ import Checkbox from '@material-ui/core/Checkbox'
 import InputLabel from '@material-ui/core/InputLabel'
 
 import { colors } from '../../constants/styles'
-
 import { targetValuesFields } from '../fe-utils/targetValuesUtil'
 
 const BarChartFields = ({ classes, formValues, setFormValues, studies }) => {
@@ -100,15 +99,15 @@ const BarChartFields = ({ classes, formValues, setFormValues, studies }) => {
         fullWidth
       />
       <div className={classes.formLabelRow}>
-        <InputLabel htmlFor='public_checkbox' className={classes.publicText}>
+        <InputLabel htmlFor="public_checkbox" className={classes.publicText}>
           Public
         </InputLabel>
         <Checkbox
           checked={formValues.public}
           onChange={updateFormValues}
-          name='public'
-          color='default'
-          id='public_checkbox'
+          name="public"
+          color="default"
+          id="public_checkbox"
           aria-label
         />
       </div>


### PR DESCRIPTION
In the event that a user is given access to a new site, the new site was missing from the target values list of an already existing chart. This pr adds the a function that appends the new site when a user is retrieving the chart to edit. 
The screenshots display the current list of sites a user has access, another screenshot displays the list of sites with target values for a site, and the ui screenshot displays the new site as part of the target values list.

<img width="1071" alt="Screen Shot 2022-09-20 at 2 27 34 PM" src="https://user-images.githubusercontent.com/19805355/191337172-2bc124c4-2b29-4476-9971-d06efa685df8.png">
<img width="1060" alt="Screen Shot 2022-09-20 at 2 29 27 PM" src="https://user-images.githubusercontent.com/19805355/191337175-c13f2afe-f2ab-42eb-b1fe-a987c3b20610.png">
<img width="572" alt="Screen Shot 2022-09-20 at 2 29 45 PM" src="https://user-images.githubusercontent.com/19805355/191337177-81cf027c-6ec9-4c4a-ad72-29150cc1ddc6.png">
