### PR TITLE
Local and Foreign Field

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -757,9 +757,13 @@ router
         {
           $lookup: {
             from: 'users',
-            localField: 'owner',
-            foreignField: 'uid',
+            let: { owner: '$owner' },
             pipeline: [
+              {
+                $match: {
+                  $expr: { $eq: ['$$owner', '$uid'] },
+                },
+              },
               {
                 $project: {
                   icon: 1,


### PR DESCRIPTION
* The version of mongodb in dpdash does not support local and foreign field. the link below was helpful in fixing this.

[Link to stack overflow explanation](https://stackoverflow.com/questions/66748716/lookup-with-pipeline-may-not-specify-localfield-or-foreignfield#:~:text=You%20can%20either,%3A1%20%7D%20%7D%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%20%20%7D%0A%5D)))

<img width="1014" alt="Screen Shot 2022-09-29 at 9 58 14 AM" src="https://user-images.githubusercontent.com/19805355/193067277-f84bdd7d-5be5-4226-9e6f-416505b13303.png">
<img width="1243" alt="Screen Shot 2022-09-29 at 9 58 31 AM" src="https://user-images.githubusercontent.com/19805355/193067278-f490ec7d-9107-4a86-8d99-dd505d83d524.png">
