### PR TITLE
Fix bar graph exceeding 100%

### DIFF
--- a/server/controllers/chartsController.js
+++ b/server/controllers/chartsController.js
@@ -56,14 +56,15 @@ const postProcessData = (data, studyTotals) => {
   }
 
   for (const [study, values] of processedDataBySite) {
-    const studySectionTotals = studyTotals[study]
-    const count = studySectionTotals.targetTotal
-      ? studySectionTotals.targetTotal - studySectionTotals.count
-      : 0
-    const percent = studyCountsToPercentage(
-      count,
-      studySectionTotals.targetTotal ?? studySectionTotals.count
+    const { targetTotal, count: currentSiteCount } = studyTotals[study]
+    const isTargetGreaterThanCount =
+      targetTotal && targetTotal > currentSiteCount
+    const count = isTargetGreaterThanCount ? targetTotal - currentSiteCount : 0
+    const studySectionTargetValue = calculateStudySectionTargetValue(
+      targetTotal,
+      currentSiteCount
     )
+    const percent = studyCountsToPercentage(count, studySectionTargetValue)
 
     processedDataBySite.set(study, {
       ...values,
@@ -193,4 +194,18 @@ export const graphDataController = async (dataDb, userAccess, chart_id) => {
     labels: Array.from(labelMap.values()),
     studyTotals,
   }
+}
+
+function calculateStudySectionTargetValue(
+  studySectionTotalTarget,
+  studySectionTotalCount
+) {
+  if (
+    !!studySectionTotalTarget &&
+    studySectionTotalTarget > studySectionTotalCount
+  ) {
+    return studySectionTotalTarget
+  }
+
+  return studySectionTotalCount || 0
 }


### PR DESCRIPTION
When a bar in the graph exceeds 100% the NA section has a negative percentage. We default the value to zero.

<img width="1361" alt="Screen Shot 2022-10-06 at 1 27 14 PM" src="https://user-images.githubusercontent.com/19805355/194381131-7c743e56-c8d1-4e5b-a62a-467b763cfdcb.png">
In the above screenshot one value exceeds 225% but the negative N/A percentage displays it as 180%

<img width="1369" alt="Screen Shot 2022-10-06 at 1 30 09 PM" src="https://user-images.githubusercontent.com/19805355/194381254-3ac6152d-b9b9-4ff8-a158-a36603408418.png">
Defaulting to zero in these cases represents the bar section completely