### PR TITLE
Remove percentages from charts tooltips

### DIFF
--- a/views/components/GraphTable/helpers.js
+++ b/views/components/GraphTable/helpers.js
@@ -1,5 +1,8 @@
-import { TOTAL_LABEL, TOTALS } from '../../../constants'
-import { studyCountsToPercentage } from '../../fe-utils/helpers'
+import { TOTAL_LABEL, TOTALS, N_A } from '../../../constants'
+import {
+  studyCountsToPercentage,
+  formatAsPercentage,
+} from '../../fe-utils/helpers'
 
 export const graphTableRowDataBySite = (dataBySite) => {
   return dataBySite
@@ -20,3 +23,13 @@ const sortAllSitesBeforeTotalsSite = (siteA, siteB) => {
   if (siteA.name === TOTALS) return -1
   if (siteB.name === TOTALS) return -1
 }
+
+export const formatSiteData = (studyCounts, studyTargets, studyPercentage) =>
+  !!studyTargets
+    ? `${studyCounts} / ${studyTargets} (${formatAsPercentage(
+        studyPercentage
+      )})`
+    : `${studyCounts} / (${formatAsPercentage(studyPercentage)})`
+
+export const graphTableColumns = (columns) =>
+  columns.filter((column) => column.name !== N_A).concat({ name: TOTAL_LABEL })

--- a/views/components/GraphTable/index.jsx
+++ b/views/components/GraphTable/index.jsx
@@ -7,8 +7,11 @@ import {
   Table,
   Paper,
 } from '@material-ui/core'
-import { formatSiteData, graphTableColumns } from '../../fe-utils/helpers'
-import { graphTableRowDataBySite } from './helpers'
+import {
+  graphTableRowDataBySite,
+  formatSiteData,
+  graphTableColumns,
+} from './helpers'
 
 const GraphTable = ({ graph }) => {
   if (!graph) return null

--- a/views/components/Graphs/BarGraphTooltip.jsx
+++ b/views/components/Graphs/BarGraphTooltip.jsx
@@ -11,7 +11,7 @@ const BarGraphTooltip = ({ classes, active, payload, label, studyTotals }) => {
     <div className={classes.tooltipContainer}>
       <div className={classes.tooltipHeaderRow}>
         <div className={classes.tooltipLabelColumn}>{label}</div>
-        <div className={classes.tooltipValueColumn}>Value / Target (%)</div>
+        <div className={classes.tooltipValueColumn}>Value / Target</div>
       </div>
       {siteTooltipContent(payload, studyTotals[label]).map(
         ({ labelColumn, valueColumn }) => {

--- a/views/fe-utils/helpers.js
+++ b/views/fe-utils/helpers.js
@@ -1,8 +1,4 @@
-import { N_A, TOTAL_LABEL } from '../../constants'
-
 export const formatAsPercentage = (value = 0) => value.toFixed(0) + '%'
-
-export const formatTooltipTargets = (target) => target || N_A
 
 export const studyCountsToPercentage = (studyCount, targetTotal) => {
   if (!targetTotal || Number.isNaN(+studyCount) || Number.isNaN(+targetTotal)) {
@@ -12,12 +8,5 @@ export const studyCountsToPercentage = (studyCount, targetTotal) => {
   return (+studyCount / +targetTotal) * 100
 }
 
-export const formatSiteData = (studyCounts, studyTargets, studyPercentage) =>
-  !!studyTargets
-    ? `${studyCounts} / ${formatTooltipTargets(
-        studyTargets
-      )} (${formatAsPercentage(studyPercentage)})`
-    : `${studyCounts} / (${formatAsPercentage(studyPercentage)})`
-
-export const graphTableColumns = (columns) =>
-  columns.filter((column) => column.name !== N_A).concat({ name: TOTAL_LABEL })
+export const formatTooltipData = (studyCounts = 0, studyTargets) =>
+  !!studyTargets ? `${studyCounts} / ${studyTargets}` : `${studyCounts}`

--- a/views/fe-utils/siteTooltipContent.js
+++ b/views/fe-utils/siteTooltipContent.js
@@ -1,10 +1,9 @@
 import { N_A, TOTAL_LABEL } from '../../constants'
-import { studyCountsToPercentage, formatSiteData } from './helpers'
+import { formatTooltipData } from './helpers'
 
 export const siteTooltipContent = (siteData, siteTotals) => {
   const { count, targetTotal } = siteTotals
   const tooltipData = []
-  const siteTotalPercent = studyCountsToPercentage(count, targetTotal)
 
   siteData
     .filter(({ name }) => name !== N_A)
@@ -13,13 +12,8 @@ export const siteTooltipContent = (siteData, siteTotals) => {
         const {
           counts: { [valueName]: siteCount },
           targets: { [valueName]: siteTarget },
-          percentages: { [valueName]: sitePercentage },
         } = payload
-        const valueColumn = formatSiteData(
-          siteCount,
-          siteTarget,
-          sitePercentage
-        )
+        const valueColumn = formatTooltipData(siteCount, siteTarget)
         const rowValue = { labelColumn: valueName, valueColumn }
         tooltipData.push(rowValue)
       }
@@ -27,7 +21,7 @@ export const siteTooltipContent = (siteData, siteTotals) => {
 
   tooltipData.push({
     labelColumn: TOTAL_LABEL,
-    valueColumn: formatSiteData(count, targetTotal, siteTotalPercent),
+    valueColumn: formatTooltipData(count, targetTotal),
   })
 
   return tooltipData

--- a/views/styles/chart_styles.js
+++ b/views/styles/chart_styles.js
@@ -142,5 +142,6 @@ export const chartStyles = (theme) => ({
   tooltipValueColumn: {
     display: 'flex',
     flex: '3',
+    justifyContent: 'center',
   },
 })


### PR DESCRIPTION
Removed percentages from tooltip

<img width="1166" alt="Screen Shot 2022-10-11 at 10 44 12 AM" src="https://user-images.githubusercontent.com/19805355/195127159-f02002a4-67c6-4bad-8545-4e2816e2ab81.png">
<img width="1361" alt="Screen Shot 2022-10-11 at 10 44 27 AM" src="https://user-images.githubusercontent.com/19805355/195127162-0824fc37-4d76-4859-9c04-e79caf783dd8.png">
