### PR TITLE
209 when site is missing targets hide target from tooltip header

### DIFF
--- a/views/components/BarGraphTooltip/helpers.js
+++ b/views/components/BarGraphTooltip/helpers.js
@@ -1,5 +1,13 @@
-import { N_A, TOTAL_LABEL } from '../../constants'
-import { formatTooltipData } from './helpers'
+import { N_A, TOTAL_LABEL } from '../../../constants'
+
+const formatTooltipData = (studyCounts = 0, studyTargets) =>
+  !!studyTargets ? `${studyCounts} / ${studyTargets}` : `${studyCounts}`
+
+export const isTargetShown = (chartPayload) =>
+  chartPayload.some(
+    ({ name: siteName, payload: sitePayload }) =>
+      !!sitePayload.targets[siteName]
+  )
 
 export const siteTooltipContent = (siteData, siteTotals) => {
   const { count, targetTotal } = siteTotals

--- a/views/components/BarGraphTooltip/index.jsx
+++ b/views/components/BarGraphTooltip/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { TOTAL_LABEL } from '../../../constants'
-import { siteTooltipContent } from '../../fe-utils/siteTooltipContent'
+import { isTargetShown, siteTooltipContent } from './helpers'
 
 const BarGraphTooltip = ({ classes, active, payload, label, studyTotals }) => {
   if (!active || !payload?.length) {
@@ -11,7 +11,9 @@ const BarGraphTooltip = ({ classes, active, payload, label, studyTotals }) => {
     <div className={classes.tooltipContainer}>
       <div className={classes.tooltipHeaderRow}>
         <div className={classes.tooltipLabelColumn}>{label}</div>
-        <div className={classes.tooltipValueColumn}>Value / Target</div>
+        <div className={classes.tooltipValueColumn}>
+          {isTargetShown(payload) ? 'Value / Target' : 'Value'}
+        </div>
       </div>
       {siteTooltipContent(payload, studyTotals[label]).map(
         ({ labelColumn, valueColumn }) => {

--- a/views/components/Graphs/BarGraph.jsx
+++ b/views/components/Graphs/BarGraph.jsx
@@ -10,7 +10,7 @@ import {
   YAxis,
   Tooltip,
 } from 'recharts'
-import BarGraphTooltip from './BarGraphTooltip'
+import BarGraphTooltip from '../BarGraphTooltip'
 
 import { routes } from '../../routes/routes'
 

--- a/views/fe-utils/helpers.js
+++ b/views/fe-utils/helpers.js
@@ -7,6 +7,3 @@ export const studyCountsToPercentage = (studyCount, targetTotal) => {
 
   return (+studyCount / +targetTotal) * 100
 }
-
-export const formatTooltipData = (studyCounts = 0, studyTargets) =>
-  !!studyTargets ? `${studyCounts} / ${studyTargets}` : `${studyCounts}`


### PR DESCRIPTION
condition to display copy 'Target' on tooltip

<img width="1197" alt="Screen Shot 2022-10-17 at 10 28 07 AM" src="https://user-images.githubusercontent.com/19805355/196205281-c6403c97-00d9-4ee0-9519-6931c11dfbf1.png">
<img width="1193" alt="Screen Shot 2022-10-17 at 10 27 54 AM" src="https://user-images.githubusercontent.com/19805355/196205260-0ec3cbff-9ff1-4f20-bb0a-95558b96be12.png">
