### PR TITLE
Add --legacy-peer-deps to npm build

### DIFF
--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -70,7 +70,7 @@ gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc" >> /etc/yum.repos.d/mo
     npm install -g npm@latest
 
     ## install DPdash dependencies
-    npm install
+    npm install --legacy-peer-deps
     npm run transpile
 
     ## install the DPPY DPdash file scanner/importer


### PR DESCRIPTION
Add `--legacy-peer-deps` to `npm build` to prevent outdated dependencies from failing build