### PR TITLE
229 limit the sites on the chart to those that the user has access to and those that have data

### DIFF
--- a/server/controllers/chartsController/helpers.js
+++ b/server/controllers/chartsController/helpers.js
@@ -85,10 +85,13 @@ export const generateStudyTargetTotals = (chart, allowedStudies) => {
         : undefined
 
       studyTotals[study] = studyTargetTotal(studyTotals[study], newTargetValue)
-      studyTotals[TOTALS_STUDY].targetTotal = totalStudyTargetValue(
-        studyTotals[TOTALS_STUDY].targetTotal,
-        newTargetValue
-      )
+
+      if (targetValues.hasOwnProperty(study)) {
+        studyTotals[TOTALS_STUDY].targetTotal = totalStudyTargetValue(
+          studyTotals[TOTALS_STUDY].targetTotal,
+          newTargetValue
+        )
+      }
     })
   })
 

--- a/server/controllers/chartsController/helpers.test.js
+++ b/server/controllers/chartsController/helpers.test.js
@@ -130,7 +130,33 @@ describe('chartsController - helpers', () => {
       })
     })
 
-    it('totals site will have an undefined targetTotal when a site does not have a target value', () => {
+    it('generates a study targets with undefined if a known site does not include a target', () => {
+      const targetValues = { MA: '10', NY: '50', Foo: '' }
+      const allowedStudies = ['MA', 'NY', 'Foo']
+      const chart = createChart({
+        fieldLabelValueMap: [
+          createFieldLabelValue({
+            value: 'valueA',
+            label: 'labelA',
+            targetValues,
+          }),
+          createFieldLabelValue({
+            value: 'valueB',
+            label: 'labelB',
+            targetValues,
+          }),
+        ],
+      })
+
+      expect(helpers.generateStudyTargetTotals(chart, allowedStudies)).toEqual({
+        MA: { count: 0, targetTotal: 20 },
+        NY: { count: 0, targetTotal: 100 },
+        Foo: { count: 0, targetTotal: undefined },
+        Totals: { count: 0, targetTotal: undefined },
+      })
+    })
+
+    it('does not update totals data with new empty sites', () => {
       const targetValues = { MA: '10', NY: '50', Foo: '4' }
       const allowedStudies = ['MA', 'NY', 'Foo', 'Bar']
       const chart = createChart({
@@ -152,6 +178,33 @@ describe('chartsController - helpers', () => {
         MA: { count: 0, targetTotal: 20 },
         NY: { count: 0, targetTotal: 100 },
         Foo: { count: 0, targetTotal: 8 },
+        Bar: { count: 0, targetTotal: undefined },
+        Totals: { count: 0, targetTotal: 128 },
+      })
+    })
+
+    it('generates a study targets with undefined if a known site does not include a target and a new site is available', () => {
+      const targetValues = { MA: '10', NY: '50', Foo: '' }
+      const allowedStudies = ['MA', 'NY', 'Foo', 'Bar']
+      const chart = createChart({
+        fieldLabelValueMap: [
+          createFieldLabelValue({
+            value: 'valueA',
+            label: 'labelA',
+            targetValues,
+          }),
+          createFieldLabelValue({
+            value: 'valueB',
+            label: 'labelB',
+            targetValues,
+          }),
+        ],
+      })
+
+      expect(helpers.generateStudyTargetTotals(chart, allowedStudies)).toEqual({
+        MA: { count: 0, targetTotal: 20 },
+        NY: { count: 0, targetTotal: 100 },
+        Foo: { count: 0, targetTotal: undefined },
         Bar: { count: 0, targetTotal: undefined },
         Totals: { count: 0, targetTotal: undefined },
       })

--- a/views/ViewChart.react.js
+++ b/views/ViewChart.react.js
@@ -6,7 +6,7 @@ import { withStyles } from '@material-ui/core/styles'
 import { Typography } from '@material-ui/core'
 import { chartStyles } from './styles/chart_styles'
 import AppLayout from './layouts/AppLayout'
-import BarGraph from './components/Graphs/BarGraph'
+import BarGraph from './components/BarGraph'
 import GraphTable from './components/GraphTable'
 
 const ViewChart = ({ graph, classes }) => {

--- a/views/components/BarGraph/helpers.js
+++ b/views/components/BarGraph/helpers.js
@@ -1,0 +1,16 @@
+const TOTALS_STUDY = 'Totals'
+
+export const sortDataBySite = (dataBySite) =>
+  dataBySite.sort((siteNameA, siteNameB) => {
+    if (siteNameA.name === TOTALS_STUDY) {
+      return -1
+    }
+    if (siteNameB.name === TOTALS_STUDY) {
+      return 1
+    }
+
+    return siteNameA.name > siteNameB.name ? 1 : -1
+  })
+
+export const sanitizeSiteData = (siteData) =>
+  siteData.filter((site) => site.totalsForStudy.count > 0)

--- a/views/components/BarGraph/helpers.test.js
+++ b/views/components/BarGraph/helpers.test.js
@@ -1,0 +1,211 @@
+import * as barGraphHelpers from './helpers'
+
+describe('BarGraph - helpers', () => {
+  describe(barGraphHelpers.sortDataBySite, () => {
+    it('sorts site data by name alphabetically', () => {
+      const dataBySite = [
+        {
+          name: 'CA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'YA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'LA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'ProNET',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'MA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+      ]
+
+      expect(barGraphHelpers.sortDataBySite(dataBySite)).toEqual([
+        {
+          name: 'CA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'LA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'MA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'ProNET',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'YA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+      ])
+    })
+
+    it('places Totals first and then sorts site data by name alphabetically', () => {
+      const dataBySite = [
+        {
+          name: 'CA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'YA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'LA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'Totals',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'ProNET',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'MA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+      ]
+
+      expect(barGraphHelpers.sortDataBySite(dataBySite)).toEqual([
+        {
+          name: 'Totals',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'CA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'LA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'MA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'ProNET',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+        {
+          name: 'YA',
+          counts: {},
+          targets: {},
+          totalsForStudy: {},
+        },
+      ])
+    })
+  })
+
+  describe(barGraphHelpers.sanitizeSiteData, () => {
+    it('filters site that have total count data', () => {
+      const dataBySite = [
+        {
+          name: 'CA',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 4 },
+        },
+        {
+          name: 'YA',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 0 },
+        },
+        {
+          name: 'LA',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 3 },
+        },
+        {
+          name: 'ProNET',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 5 },
+        },
+        {
+          name: 'MA',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 0 },
+        },
+      ]
+
+      expect(barGraphHelpers.sanitizeSiteData(dataBySite)).toEqual([
+        {
+          name: 'CA',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 4 },
+        },
+        {
+          name: 'LA',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 3 },
+        },
+        {
+          name: 'ProNET',
+          counts: {},
+          targets: {},
+          totalsForStudy: { count: 5 },
+        },
+      ])
+    })
+  })
+})

--- a/views/components/BarGraph/index.jsx
+++ b/views/components/BarGraph/index.jsx
@@ -12,21 +12,12 @@ import {
 } from 'recharts'
 import BarGraphTooltip from '../BarGraphTooltip'
 
+import { sortDataBySite, sanitizeSiteData } from './helpers'
+
 import { routes } from '../../routes/routes'
 
-const TOTALS_STUDY = 'Totals'
-
 const BarGraph = ({ graph, classes }) => {
-  const siteData = graph.dataBySite.sort((siteNameA, siteNameB) => {
-    if (siteNameA.name === TOTALS_STUDY) {
-      return -1
-    }
-    if (siteNameB.name === TOTALS_STUDY) {
-      return 1
-    }
-
-    return siteNameA.name > siteNameB.name ? 1 : -1
-  })
+  const siteData = sortDataBySite(graph.dataBySite)
 
   if (!siteData.length) {
     return (
@@ -39,7 +30,7 @@ const BarGraph = ({ graph, classes }) => {
 
   return (
     <ResponsiveContainer width="100%" height={500}>
-      <BarChart width={600} height={400} data={siteData}>
+      <BarChart width={600} height={400} data={sanitizeSiteData(siteData)}>
         <Legend
           verticalAlign="top"
           height={50}


### PR DESCRIPTION
This pr fixes #229 
New sites with data will cause zero impact on totals calculation. Sites without data will not appear on a chart and will be displayed on the table. 
### ~~Previously Sites with data but no counts would appear on graph~~ (Fixed)
<img width="1240" alt="Screen Shot 2022-11-09 at 2 53 14 PM" src="https://user-images.githubusercontent.com/19805355/200927973-e0669836-0e9d-49d4-8fcd-c3cc8ca3a894.png">

###  Chart with targets set on sites and new sites with data
<img width="1194" alt="Screen Shot 2022-11-09 at 1 58 27 PM" src="https://user-images.githubusercontent.com/19805355/200918717-67d2f6a9-678d-47fe-ad44-a3a1d7ac214f.png">

### Chart with all sites and targets set for all sites
<img width="1196" alt="Screen Shot 2022-11-09 at 1 58 38 PM" src="https://user-images.githubusercontent.com/19805355/200919079-8694df34-55df-4276-917e-dc9e101905a7.png">

### Chart of sites with targets, sites without targets and new sites introduced
<img width="1192" alt="Screen Shot 2022-11-09 at 1 58 52 PM" src="https://user-images.githubusercontent.com/19805355/200919191-8e916792-1f8c-4429-8dea-44b7be2c2d73.png">

### No value group chart
<img width="1198" alt="Screen Shot 2022-11-09 at 2 00 46 PM" src="https://user-images.githubusercontent.com/19805355/200919283-33f80375-ccef-4f1c-a5e5-d4f11bf89fd6.png">


