### PR TITLE
Clear previous logs

### DIFF
--- a/singularity/run.sh
+++ b/singularity/run.sh
@@ -20,6 +20,11 @@ export RABBITMQ_CONF_ENV_FILE=/data/dpdash/configs/rabbitmq-env.conf
 # vars for celery worker
 export dppy_config=/data/dpdash/configs/dppy.conf
 
+# clear previous logs
+rm -f ~/.pm2/logs/*
+rm -f /data/dpdash/mongodb/logs/mongod.log
+rm -f /data/dpdash/mongodb/dbs/diagnostic.data/*
+
 # start mongodb, celery, and rabbit
 echo "Starting superivsord..."
 supervisord -c /data/dpdash/configs/supervisord.conf


### PR DESCRIPTION
I have been doing them all manually for a long time now, might as well include them in `run.sh`. There was not a single time when I had to look at previous logs after restarting DPdash. Also, previous logs append to existing files making it difficult to pinpoint the current error.