### PR TITLE
Allow chart description to wrap around page

### DIFF
--- a/views/ViewChart.react.js
+++ b/views/ViewChart.react.js
@@ -21,9 +21,7 @@ const ViewChart = ({ graph, classes }) => {
     <AppLayout title={title}>
       {description && (
         <div className={classes.viewChartRow}>
-          <Typography variant="subtitle1">
-            <pre style={{ fontFamily: 'inherit' }}>{description}</pre>
-          </Typography>
+          <Typography variant="subtitle1">{description}</Typography>
         </div>
       )}
       <div className={classes.filterFormContainer}>

--- a/views/styles/chart_styles.js
+++ b/views/styles/chart_styles.js
@@ -147,6 +147,7 @@ export const chartStyles = (theme) => ({
   viewChartRow: {
     display: 'flex',
     justifyContent: 'space-between',
+    paddingBottom: '25px',
   },
   filterFormContainer: {
     paddingBottom: '75px',


### PR DESCRIPTION
A long chart description extends beyond the chart, this pr makes the description wrap around.