### PR TITLE
#275 Fix creating default configs at login

### DIFF
--- a/server/utils/passport/local-login.js
+++ b/server/utils/passport/local-login.js
@@ -25,7 +25,7 @@ export default (req, res, next, user) => {
 
     appDb.collection(collections.configs).findOne(
       {
-        ower: uid,
+        owner: uid,
       },
       function (err, configObj) {
         if (err) {


### PR DESCRIPTION
closes #275 

When a user logs on to dpdash a new default config is created. This behavior is unexpected.