### PR TITLE
284 update the UI of the filters on the chart page

### DIFF
--- a/constants/vars.js
+++ b/constants/vars.js
@@ -5,6 +5,7 @@ export const DISALLOWED_STUDIES = ['combined', 'files']
 export const FILTER_CATEGORIES = {
   chrcrit_part: 'Cohort',
   included_excluded: 'Included Criteria',
+  sex_at_birth: 'Sex At Birth',
 }
 export const TRUE_STRING = 'true'
 export const FALSE_STRING = 'false'

--- a/views/forms/CharFilterForm/index.jsx
+++ b/views/forms/CharFilterForm/index.jsx
@@ -4,7 +4,7 @@ import {
   Checkbox,
   List,
   ListItem,
-  ListItemText,
+  Typography,
   InputLabel,
 } from '@material-ui/core'
 import Form from '../Form'
@@ -37,42 +37,43 @@ const ChartFilterForm = ({ initialValues, onSubmit, classes }) => {
         return onSubmit(values)
       }}
     >
-      {Object.keys(values).map((filterKey) => {
-        return (
-          <List
-            id={filterKey}
-            key={filterKey}
-            component="nav"
-            className={classes.filters}
-          >
-            <ListItemText
-              primary={FILTER_CATEGORIES[filterKey]}
-              className={classes.filterText}
-            />
-            <div className={classes.filtersContainer}>
-              {values[filterKey].map((filter) => {
-                const filterID = `${filterKey}-${filter.name}`
+      <div className={classes.filterForm}>
+        {Object.keys(values).map((filterKey) => {
+          return (
+            <div key={filterKey}>
+              <Typography variant="subtitle2" className={classes.filterText}>
+                {FILTER_CATEGORIES[filterKey]}
+              </Typography>
+              <div className={classes.filtersContainer}>
+                {values[filterKey].map((filter) => {
+                  const filterID = `${filterKey}-${filter.name}`
 
-                return (
-                  <List key={filterID} component="div" disablePadding>
-                    <ListItem className={classes.filterNested}>
-                      <InputLabel htmlFor={filterID}>
-                        {filter.name}
+                  return (
+                    <List key={filterID} component="div" disablePadding>
+                      <ListItem className={classes.filterNested}>
+                        <InputLabel
+                          htmlFor={filterID}
+                          className={classes.filterLabel}
+                        >
+                          {filter.name}
+                        </InputLabel>
                         <Checkbox
                           checked={filter.value === TRUE_STRING}
                           onChange={({ target }) => onChange(target, filterKey)}
                           name={filter.name}
                           id={filterID}
+                          className={classes.filterCheckbox}
                         />
-                      </InputLabel>
-                    </ListItem>
-                  </List>
-                )
-              })}
+                      </ListItem>
+                    </List>
+                  )
+                })}
+              </div>
             </div>
-          </List>
-        )
-      })}
+          )
+        })}
+      </div>
+
       <div className={classes.filterButtonContainer}>
         <Button
           type="submit"

--- a/views/styles/chart_styles.js
+++ b/views/styles/chart_styles.js
@@ -150,32 +150,43 @@ export const chartStyles = (theme) => ({
     paddingBottom: '25px',
   },
   filterFormContainer: {
-    paddingBottom: '75px',
+    paddingBottom: '50px',
   },
-  filters: {
-    width: '425px',
+  filterForm: {
     display: 'flex',
-    flexDirection: 'column',
+    width: '100%',
+  },
+  filterText: {
+    marginTop: 0,
+    marginBottom: 0,
+    textIndent: '15px',
   },
   filtersContainer: {
     display: 'flex',
-    justifyContent: 'space-between',
-  },
-  filterText: {
-    paddingRight: theme.spacing.unit * 2,
-    textIndent: '15px',
+    paddingLeft: '15px',
   },
   filterNested: {
-    paddingTop: 0,
-    paddingBottom: 0,
+    padding: 0,
+  },
+  filterLabel: {
+    fontSize: '12px',
+  },
+  filterCheckbox: {
+    transform: 'scale(.75)',
+    paddingLeft: '0px',
   },
   filterButtonContainer: {
     paddingTop: '20px',
     width: '158px',
-    display: 'flex',
-    justifyContent: 'space-around',
+    paddingLeft: '15px',
   },
   submitFiltersButton: {
     alignSelf: 'flex-end',
+  },
+  [theme.breakpoints.down('md')]: {
+    filterForm: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
   },
 })


### PR DESCRIPTION
closes #284 

Update styles to filters on screens larger than a tablet filters will be inline, for smaller screens the filters will be stacked vertically but filters will be inline.

<img width="1227" alt="Screen Shot 2023-04-10 at 1 33 50 PM" src="https://user-images.githubusercontent.com/19805355/230982934-e50c04cd-a8af-4471-bbbf-bdf999d51e68.png">
<img width="1440" alt="Screen Shot 2023-04-10 at 1 34 02 PM" src="https://user-images.githubusercontent.com/19805355/230982937-ff81ea8d-5e88-4fc7-b7a3-9b2074645c9f.png">
