### PR TITLE
Fix bundling of js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,5 @@
 
   <body>
     <div id="root"></div>
-    <script src="/js/bundle.js"></script>
   </body>
 </html>

--- a/server/app.js
+++ b/server/app.js
@@ -208,7 +208,7 @@ app.use(
   express.static(path.join(__dirname, '../public/img'))
 )
 
-app.get('*', async (req, res) => {
+app.get('/*', async (req, res) => {
   return res.sendFile(
     path.join(__dirname, '..', 'app_build', 'index.html'),
     (err) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, outputDirectory),
     filename: 'js/bundle.js',
+    publicPath: '/',
   },
   resolve: {
     fallback: {


### PR DESCRIPTION
* there was a console error from param routes about refusing to serve javascript. This fixes that issue.
By adding the public path and the forward slash to the wildcard route we have the proper routing to the bundle.js file that is needed by the client side routing when the client side requests that route.
There was also an additional script tag being appended to the index.html at build, so by removing it from the index.html file, webpack then adds the script tag with the proper hash to the output index.html file that is being served. 

<img width="1306" alt="Screen Shot 2023-07-21 at 10 02 55 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/9e5f2c5f-10f8-4b5f-9b83-6d38d091ad9b">
