### PR TITLE
Revert back to mongo 4.4

### DIFF
--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -43,15 +43,14 @@ From:centos:7.4.1708
     yum -y install nodejs
 
     ## install the MongoDB document database
-    echo -e "[mongodb-org-6.0]
+    echo -e "[mongodb-org-4.4]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/6.0/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.4/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-6.0.asc" >> /etc/yum.repos.d/mongodb-org-6.0.repo
+gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc" >> /etc/yum.repos.d/mongodb-org-4.4.repo
 
     yum -y install mongodb-org
-    yum install -y mongodb-mongosh
 
 
     ## install the Celery asyncronous task queue


### PR DESCRIPTION
This pr reverts Singularity mongo version to v4.4.

We are doing this because we attempted to upgrade to v6.0 but the client's hardware that runs the application is missing AVX support. Without this avx support their system is unable to be upgraded to any other version past 4.4. 

