### PR TITLE
Deployment: Move Build step out of setup.sh and into the image build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "webpack",
+    "build": "NODE_ENV=production webpack",
     "build:watch": "webpack --watch",
     "transpile": "npx babel ./server --out-dir dist",
     "dev": "NODE_ENV=development concurrently \"npm run serve:watch\" \"npm run build:watch\"",

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -72,6 +72,8 @@ gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc" >> /etc/yum.repos.d/mo
     ## install DPdash dependencies
     npm install --legacy-peer-deps
     npm run transpile
+    npm run build
+
 
     cd ..
 

--- a/singularity/setup.sh
+++ b/singularity/setup.sh
@@ -33,10 +33,4 @@ sleep 10 && /usr/lib/rabbitmq/bin/rabbitmqctl stop
 echo '***************Setting up CELERY***************'
 export dppy_config=/data/dpdash/configs/dppy.conf
 
-
-echo '***************Building DPdash***************'
-echo 'Please wait, this may take upwards of 10-15 minutes to complete.'
-cd /sw/apps/dpdash
-npm run build
-
 echo '****************Set Up Complete****************'


### PR DESCRIPTION
The issue: During the build process of the frontend webpack needs access to the file system to read and write files, but the image is read only.

This pr moves the build process from running within the read only container and into the creation of the singularity image file after the npm install/transpile step. 

This is the link to the message. https://gnardog.slack.com/archives/C03KGHSSTNC/p1690574985288589