### PR TITLE
362 add rabbitmq to docker

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,0 +1,16 @@
+# SERVER_PORT=8000
+# MONGODB_PORT=27017
+# MONGODB_ADMIN_USER=dpdash
+# MONGODB_ADMIN_PASSWORD=Get the password from whoever gave you the backup.tar for mongodb. Should match the .env file
+# MONGODB_URI=mongodb://${MONGODB_ADMIN_USER}:${MONGODB_ADMIN_PASSWORD}@mongodb:27017/dpdmongo?authSource=admin
+# SESSION_SECRET=This can be any secure value
+
+# RABBIT_PORT=5672
+# RABBIT_HOST=app-tier
+# RABBIT_USERNAME=dpdash
+# RABBIT_PASSWORD=Use any secure value, but make sure it's the same in the .env file
+# RABBIT_ADDRESS=amqp://${RABBIT_USERNAME}:${RABBIT_PASSWORD}@app-tier:5672
+# RABBIT_PUBLISHER_QUEUE=dpdash
+# RABBIT_CONSUMER_QUEUE=dpdashResponse
+
+# LOG_FILE_PATH=logs/app.log

--- a/.env.sample
+++ b/.env.sample
@@ -1,18 +1,5 @@
-# SERVER_PORT=
+# MONGODB_ADMIN_USER=dpdash
+# MONGODB_ADMIN_PASSWORD=get the password from whoever gave you the backup.tar for mongodb
 
-# MONGODB_PORT=
-# MONGODB_ADMIN_USER=
-# MONGODB_ADMIN_PASSWORD=
-# MONGODB_URI=
-
-# SESSION_SECRET=
-
-# RABBIT_PORT=
-# RABBIT_HOST=
-# RABBIT_USERNAME=
-# RABBIT_PASSWORD=
-# RABBIT_PUBLISHER_QUEUE=
-# RABBIT_CONSUMER_QUEUE=
-# RABBIT_ADDRESS=
-
-# LOG_FILE_PATH=
+# RABBIT_USERNAME=dpdash
+# RABBIT_PASSWORD=use any secure value, but make sure it's the same in .env.development

--- a/Docker_SETUP.md
+++ b/Docker_SETUP.md
@@ -12,14 +12,48 @@ Download Docker for your os type [Docker Website](https://www.docker.com/)
 
 ## Set Up ENV Variables
 
-- Create a env.development file
+- Create a .env file
 - Add these [variables to your file ](/.env.sample)
-- Ask a Team Member for the values
+- Create a env.development file
+- Add these [variables to your file ](/.env.development.sample)
+- Ask a Team Member for the values and an export of their `dpdash-mongodb` volume
 
 ## Import Data
 
-- Get a data dump from your team member and import it
+Create a new docker volume with the `dpdash-mongodb`.
 
+```sh
+docker volume create dpdash-mongodb
+```
+
+Create a container to hold the volume
+```sh
+ docker run -v dpdash-mongodb:/dpdash-mongodb --name mongo_restore ubuntu /bin/bash
+```
+
+Unpack the `backup.tar` file into the volume.
+
+```sh
+ docker run --rm --volumes-from mongo_restore -v $(pwd):/backup ubuntu bash -c "cd /dpdash-mongodb   && tar xvf /backup/backup.tar --strip 1"
+
+```
 ## Start the project
 
-- Once Set up, use the command `make docker-dev`
+- Once Set up, use the command `docker compose up`
+
+
+## For Onboarding: Export Data
+
+Spin up a container with the volume. Use Ubuntu because we gotta keep Mongo from writing to it.
+
+```sh
+ docker run -v dpdash-mongodb:/dpdash-mongodb --name mongo_backup ubuntu /bin/bash
+```
+
+Copy the volume contents to `./backup.tar`
+
+```sh
+docker run --rm --volumes-from mongo_backup -v $(pwd):/backup ubuntu tar cvf /backup/backup.tar /dpdash-mongodb
+```
+
+

--- a/dev.rabbitmq.Dockerfile
+++ b/dev.rabbitmq.Dockerfile
@@ -1,0 +1,18 @@
+FROM rabbitmq
+
+ADD rabbitmq-init.sh /rabbitmq-init.sh
+RUN chmod +x /rabbitmq-init.sh
+
+ARG RABBIT_USERNAME=something
+ENV RABBIT_USERNAME=${RABBIT_USERNAME}
+
+ARG RABBIT_PASSWORD=something
+ENV RABBIT_PASSWORD=${RABBIT_PASSWORD}
+
+ENV RABBITMQ_PID_FILE=/var/lib/rabbitmq/mnesia/rabbitmq
+
+
+EXPOSE 5671 5672
+
+# Define default command
+CMD ["/rabbitmq-init.sh"]

--- a/dev.server.Dockerfile
+++ b/dev.server.Dockerfile
@@ -1,12 +1,10 @@
 FROM node:16
 
-COPY package.json package-lock.json ./
-
-RUN npm install --legacy-peer-deps
-
 COPY . /src
 
 WORKDIR /src
+
+RUN npm install --legacy-peer-deps
 
 CMD [ "npm", "run", "dev" ]
 

--- a/dev.server.Dockerfile
+++ b/dev.server.Dockerfile
@@ -4,7 +4,9 @@ COPY package.json package-lock.json ./
 
 RUN npm install --legacy-peer-deps
 
-COPY . .
+COPY . /src
+
+WORKDIR /src
 
 CMD [ "npm", "run", "dev" ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     env_file: .env.development
     ports:
       - 8000:8000
+    volumes:
+      - .:/src
     networks:
       - default
       - app-tier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,19 +4,47 @@ services:
   node-app:
     build:
       dockerfile: dev.server.Dockerfile
+      context: .
     depends_on:
       - mongodb
-    env_file:
-      - .env.development
+      - rabbitmq
+    env_file: .env.development
     ports:
-      - $SERVER_PORT:$SERVER_PORT
+      - 8000:8000
+    networks:
+      - default
+      - app-tier
   mongodb:
     image: mongo:4.4
     restart: unless-stopped
-    ports:
-      - $MONGODB_PORT:$MONGODB_PORT
     environment:
-      MONGO_INITDB_ROOT_USERNAME: $MONGODB_ADMIN_USER
-      MONGO_INITDB_ROOT_PASSWORD: $MONGODB_ADMIN_PASSWORD
+      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_ADMIN_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_ADMIN_PASSWORD}
     volumes:
-      - /data/db
+      - mongodb:/data/db
+    networks:
+      - app-tier
+  rabbitmq:
+    build:
+      dockerfile: dev.rabbitmq.Dockerfile
+      context: .
+      args:
+        - RABBIT_USERNAME=${RABBIT_USERNAME}
+        - RABBIT_PASSWORD=${RABBIT_PASSWORD}
+    hostname: 'app-tier'
+    healthcheck:
+      test: ["rabbitmq-diagnostics", "-q", "ping"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+    environment:
+      - RABBITMQ_NODE_NAME=rabbit@app-tier
+    networks:
+      - app-tier
+networks:
+  app-tier:
+    driver: bridge
+volumes:
+  mongodb:
+    name: dpdash-mongodb
+    external: true

--- a/rabbitmq-init.sh
+++ b/rabbitmq-init.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Create Rabbitmq user
+rabbitmqctl start_app
+( rabbitmqctl wait --timeout 60 $RABBITMQ_PID_FILE ; \
+rabbitmqctl add_user $RABBIT_USERNAME $RABBIT_PASSWORD 2>/dev/null ; \
+rabbitmqctl set_user_tags $RABBIT_USERNAME administrator ; \
+rabbitmqctl set_permissions -p / $RABBIT_USERNAME  ".*" ".*" ".*" ; \
+echo "*** User '$RABBIT_USERNAME' with password NOPE completed. ***" ; \
+echo "*** Log in the WebUI at port 15672 (example: http:/localhost:15672) ***") &
+
+rabbitmqctl stop_app
+# $@ is used to pass arguments to the rabbitmq-server command.
+# For example if you use it like this: docker run -d rabbitmq arg1 arg2,
+# it will be as you run in the container rabbitmq-server arg1 arg2
+rabbitmq-server $@

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -18,17 +18,8 @@ const router = Router()
 
 const basePath = basePathConfig || ''
 
-var amqpAddress =
-  'amqp://' +
-  config.rabbitmq.username +
-  ':' +
-  config.rabbitmq.password +
-  '@' +
-  config.rabbitmq.host +
-  ':' +
-  config.rabbitmq.port
 let rabbitmq_conn
-connect(amqpAddress, config.rabbitmq.opts, function (err, conn) {
+connect(process.env.RABBIT_ADDRESS, config.rabbitmq.opts, function (err, conn) {
   if (err) console.log(err)
   rabbitmq_conn = conn
 })

--- a/server/utils/importer.js
+++ b/server/utils/importer.js
@@ -4,10 +4,8 @@ import uuidV4 from 'uuid/v4';
 
 function dataImport() {
   console.log('INFO - data - connecting to queue');
-  var amqpAddress = 'amqps://' + config.rabbitmq.username;
-  amqpAddress = amqpAddress + ':' + config.rabbitmq.password;
-  amqpAddress = amqpAddress + '@' + config.rabbitmq.host + ':' + config.rabbitmq.port;
-  connect(amqpAddress, config.rabbitmq.opts, function (err, conn) {
+
+  connect(process.env.RABBIT_ADDRESS, config.rabbitmq.opts, function (err, conn) {
     if (err) {
       console.log('ERROR - rabbimtq - ' + err);
       return;


### PR DESCRIPTION
This PR:
 - Updates `docker-compose.yml` to add the RabbitMQ service and config
 - Updates `docket-compose.yml` to use an external volume for MongoDB
 - Adds the local volume mount `.:./src` to the node app so that changes to the code will cause the service to restart
 - Updates `Docker_SETUP.md` and the sample `.env` files for new Docker setup, including data import and export