### PR TITLE
389 dashboard matrix queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "serve:watch": "nodemon -r dotenv/config --exec babel-node server/bin/www.js --watch \"./server\" dotenv_config_path=./.env.development",
     "node": "DEBUG=* node ./dist/bin/www.js",
     "test": "jest",
-    "migrate:assessment_subject_data": "MONGODB_URI=$MONGODB_URI node ./scripts/data_migration/migrate_assessment_subject_day_data.js"
+    "migrate:assessment_subject_data": "MONGODB_URI=$MONGODB_URI node ./scripts/data_migration/migrate_assessment_subject_day_data.js",
+    "migrate:charts": "MONGODB_URI=$MONGODB_URI node ./scripts/data_migration/migrate_charts.js",
+    "migrate:metadata": "MONGODB_URI=$MONGODB_URI node ./scripts/data_migration/migrate_metadata.js"
   },
   "babel": {
     "presets": [

--- a/scripts/data_migration/migrate_charts.js
+++ b/scripts/data_migration/migrate_charts.js
@@ -1,0 +1,35 @@
+const { MongoClient } = require('mongodb')
+
+const CHART_COLLECTION = 'charts'
+
+async function migrateCharts() {  
+  const mongoConnection = await MongoClient.connect(process.env.MONGODB_URI, {
+    ssl: process.env.NODE_ENV === 'production',
+    useNewUrlParser: true,
+  })
+
+  const appDb = mongoConnection.db('dpdmongo')
+  const db = mongoConnection.db('dpdata')
+  const chartsCursor = await db.collection(CHART_COLLECTION).find({})
+
+  while (await chartsCursor.hasNext()) {
+    const chart = await chartsCursor.next()
+    await appDb.collection(CHART_COLLECTION).insertOne(chart)
+  }
+
+  return mongoConnection
+}
+
+module.exports = { migrateCharts }
+
+if (process.env.NODE_ENV !== 'test') {
+  migrateCharts()
+    .then(async (mongoConnection) => {
+      console.log('Done')
+      await mongoConnection.close()
+      process.exit(0)
+    }).catch(async (err) => {
+      console.error(err)
+      process.exit(1)
+    })
+  }

--- a/scripts/data_migration/migrate_charts.test.js
+++ b/scripts/data_migration/migrate_charts.test.js
@@ -1,0 +1,110 @@
+import { ObjectId } from 'mongodb';
+
+import { migrateCharts } from './migrate_charts';
+
+describe('migrateCharts', () => {
+  it('copies the chart document data in dpdata to dpdmongo', async () => {
+    const charts = [
+      {
+        "_id": new ObjectId("62e44fea1809d96c00e88ff0"),
+        "title": "Edited Form",
+        "variable": "surveys_raw_PROTECTED",
+        "assessment": "flowcheck",
+        "description": "Form Edits",
+        "fieldLabelValueMap": [
+          {
+            "value": "1",
+            "label": "VALA",
+            "color": "#2217db",
+            "targetValues": {
+              "CA": "5",
+              "ProNET": "5",
+              "LA": "5",
+              "YA": "5",
+              "MA": "5"
+            }
+          },
+          {
+            "value": "2",
+            "label": "VALB",
+            "color": "#e6bd85",
+            "targetValues": {
+              "CA": "5",
+              "ProNET": "5",
+              "LA": "5",
+              "YA": "5",
+              "MA": "5"
+            }
+          }
+        ],
+        "owner": "dpdash",
+        "updatedAt": "2022-08-24T17:29:04.882Z",
+        "sharedWith": [
+          "blockedUser"
+        ],
+        "public": true
+      },
+      {
+        "_id": new ObjectId("62ed997a76d799a7aa67b4ae"),
+        "title": "Edited FormPART 2",
+        "variable": "surveys_raw_PROTECTED",
+        "assessment": "flowcheck",
+        "description": "Form Edits",
+        "fieldLabelValueMap": [
+          {
+            "value": "1",
+            "label": "VALA",
+            "color": "#dba48f",
+            "targetValues": {
+              "CA": "5",
+              "ProNET": "5",
+              "LA": "5",
+              "YA": "5",
+              "MA": "5"
+            }
+          },
+          {
+            "value": "2",
+            "label": "VALB",
+            "color": "#156c21",
+            "targetValues": {
+              "CA": "5",
+              "ProNET": "5",
+              "LA": "5",
+              "YA": "5",
+              "MA": "5"
+            }
+          },
+          {
+            "value": "0",
+            "label": "Val0",
+            "color": "#0d0501",
+            "targetValues": {
+              "CA": "5",
+              "ProNET": "5",
+              "LA": "5",
+              "YA": "5",
+              "MA": "5"
+            }
+          }
+        ],
+        "owner": "dpdash",
+        "updatedAt": "2022-08-23T16:29:57.048Z",
+        "sharedWith": [],
+        "public": null
+      }
+    ].sort((a, b) => a._id.toString().localeCompare(b._id.toString()))
+
+    await dataDb.collection('charts').insertMany(charts)
+    
+    const connection = await migrateCharts();
+    await connection.close()
+
+    const updatedCharts = await appDb.collection('charts').find({}).toArray()
+    const sortedCharts = updatedCharts.sort((a, b) => a._id.toString().localeCompare(b._id.toString()))
+    
+    expect(sortedCharts.length).toBe(2)
+    expect(sortedCharts[0]).toEqual(charts[0])
+    expect(sortedCharts[1]).toEqual(charts[1])
+  })
+})

--- a/scripts/data_migration/migrate_metadata.js
+++ b/scripts/data_migration/migrate_metadata.js
@@ -1,0 +1,35 @@
+const { MongoClient } = require('mongodb')
+
+const METADATA_COLLECTION = 'metadata'
+
+async function migrateMetadata() {  
+  const mongoConnection = await MongoClient.connect(process.env.MONGODB_URI, {
+    ssl: process.env.NODE_ENV === 'production',
+    useNewUrlParser: true,
+  })
+
+  const appDb = mongoConnection.db('dpdmongo')
+  const db = mongoConnection.db('dpdata')
+  const metadataCursor = await db.collection(METADATA_COLLECTION).find({})
+
+  while (await metadataCursor.hasNext()) {
+    const chart = await metadataCursor.next()
+    await appDb.collection(METADATA_COLLECTION).insertOne(chart)
+  }
+
+  return mongoConnection
+}
+
+module.exports = { migrateMetadata }
+
+if (process.env.NODE_ENV !== 'test') {
+  migrateMetadata()
+    .then(async (mongoConnection) => {
+      console.log('Done')
+      await mongoConnection.close()
+      process.exit(0)
+    }).catch(async (err) => {
+      console.error(err)
+      process.exit(1)
+    })
+  }

--- a/scripts/data_migration/migrate_metadata.test.js
+++ b/scripts/data_migration/migrate_metadata.test.js
@@ -1,0 +1,114 @@
+import { ObjectId } from 'mongodb';
+
+import { migrateMetadata } from './migrate_metadata';
+
+describe('migrateMetadata', () => {
+  it('copies the metadata document data in dpdata to dpdmongo', async () => {
+    const metadata = [
+      {
+        "_id": new ObjectId("62b5d5226fc289683c85f601"),
+        "study": "CA",
+        "days": 1,
+        "subjects": [
+          {
+            "subject": "CA00063",
+            "synced": {
+              "$date": "2022-07-28T12:25:48.033Z"
+            },
+            "days": 1,
+            "study": "CA"
+          },
+          {
+            "subject": "CA00064",
+            "synced": "2022-06-24T15:15:46.423+0000",
+            "days": 1,
+            "study": "CA"
+          },
+          {
+            "subject": "CA00066",
+            "synced": "2022-06-24T15:15:46.423+0000",
+            "days": 1,
+            "study": "CA"
+          },
+          {
+            "subject": "CA00057",
+            "synced": {
+              "$date": "2022-07-28T12:25:48.007Z"
+            },
+            "days": 1,
+            "study": "CA"
+          },
+          {
+            "subject": "CA00007",
+            "synced": {
+              "$date": "2022-07-28T12:25:48.062Z"
+            },
+            "days": 1,
+            "study": "CA"
+          },
+          {
+            "subject": "CA00073",
+            "synced": "2022-06-24T15:15:46.423+0000",
+            "days": 1,
+            "study": "CA"
+          }
+        ],
+        "synced": false
+      },
+      {
+        "_id": new ObjectId("62e2804bf8e96ad36c8c61fb"),
+        "study": "files",
+        "extension": ".csv",
+        "glob": "/Users/ivanrts/Downloads/data_for_gnar/files_metadata.csv",
+        "path": "/Users/ivanrts/Downloads/data_for_gnar/files_metadata.csv",
+        "filetype": "text/csv",
+        "encoding": null,
+        "basename": "files_metadata.csv",
+        "dirname": "/Users/ivanrts/Downloads/data_for_gnar",
+        "dirty": false,
+        "synced": false,
+        "mtime": 1654738589,
+        "size": 485,
+        "uid": 501,
+        "gid": 20,
+        "mode": 33252,
+        "role": "metadata",
+        "collection": "2677f5c4-92c1-4178-aa73-5c6ad647bf9b",
+        "updated": {
+          "$date": "2022-07-28T12:25:47.852Z"
+        },
+        "days": 9999,
+        "subjects": [
+          {
+            "subject": "CA",
+            "synced": {
+              "$date": "2022-07-28T12:25:47.655Z"
+            },
+            "days": 9999,
+            "study": "files"
+          },
+          {
+            "subject": "ProNET",
+            "synced": {
+              "$date": "2022-07-28T12:25:47.102Z"
+            },
+            "days": 9999,
+            "study": "files"
+          }
+        ]
+      }
+    ].sort((a, b) => a._id.toString().localeCompare(b._id.toString()))
+
+    await dataDb.collection('metadata').insertMany(metadata)
+    
+    const connection = await migrateMetadata();
+    await connection.close()
+
+    const updatedMetadata = await appDb.collection('metadata').find({}).toArray()
+    const sortedMetadata = updatedMetadata.sort((a, b) => a._id.toString().localeCompare(b._id.toString()))
+    
+    expect(sortedMetadata.length).toBe(2)
+    expect(sortedMetadata[0]).toEqual(metadata[0])
+    expect(sortedMetadata[1]).toEqual(metadata[1])
+  })
+})

--- a/server/app.js
+++ b/server/app.js
@@ -118,7 +118,7 @@ const mongodbPromise = co(function* () {
 }).then(function (res) {
   mongodb = res.db()
   app.locals.appDb = res.db()
-  app.locals.dataDb = res.db('dpdata')
+  app.locals.dataDb = res.db()
   res.db().collection('sessions').drop()
 
   return res

--- a/server/data_processors/DashboardDataProcessor/DashboardDataProcessor.test.js
+++ b/server/data_processors/DashboardDataProcessor/DashboardDataProcessor.test.js
@@ -10,6 +10,7 @@ import { collections } from '../../utils/mongoCollections'
 
 describe('Data Processors - Dashboard', () => {
   describe(DashboardDataProcessor.calculateDashboardData, () => {
+    const subject = 'subject'
     const assessmentsFromConfig = [
       createAssessmentsFromConfig({
         assessment: 'size_of',
@@ -52,24 +53,28 @@ describe('Data Processors - Dashboard', () => {
     ]
     const jumpVariableData = [
       createSubjectDayData({
-        collection: 'jump-of-collection',
+        assessment: 'jump_of',
+        subject,
         day: 10,
         jumpVariable: 1,
       }),
       createSubjectDayData({
-        collection: 'jump-of-collection',
+        assessment: 'jump_of',
+        subject,
         day: 20,
         jumpVariable: 30,
       }),
     ]
     const sizeVariableData = [
       createSubjectDayData({
-        collection: 'size-of-collection',
+        assessment: 'size_of',
+        subject,
         day: 1,
         sizeVariable: 30,
       }),
       createSubjectDayData({
-        collection: 'size-of-collection',
+        assessment: 'size_of',
+        subject,
         day: 45,
         sizeVariable: 2,
       }),
@@ -84,6 +89,7 @@ describe('Data Processors - Dashboard', () => {
       const dashboardProcessor = new DashboardDataProcessor(
         assessmentsFromConfig,
         config,
+        subject,
         appDb,
       )
       const { matrixData } = await dashboardProcessor.calculateDashboardData()

--- a/server/data_processors/DashboardDataProcessor/DashboardDataProcessor.test.js
+++ b/server/data_processors/DashboardDataProcessor/DashboardDataProcessor.test.js
@@ -6,6 +6,7 @@ import {
   createAssessmentsFromConfig,
   createMatrixData,
 } from '../../../test/fixtures'
+import { collections } from '../../utils/mongoCollections'
 
 describe('Data Processors - Dashboard', () => {
   describe(DashboardDataProcessor.calculateDashboardData, () => {
@@ -49,43 +50,41 @@ describe('Data Processors - Dashboard', () => {
         category: 'reading',
       }),
     ]
-    const db = createDb()
     const jumpVariableData = [
       createSubjectDayData({
+        collection: 'jump-of-collection',
         day: 10,
         jumpVariable: 1,
       }),
       createSubjectDayData({
+        collection: 'jump-of-collection',
         day: 20,
         jumpVariable: 30,
       }),
     ]
     const sizeVariableData = [
       createSubjectDayData({
+        collection: 'size-of-collection',
         day: 1,
         sizeVariable: 30,
       }),
       createSubjectDayData({
+        collection: 'size-of-collection',
         day: 45,
         sizeVariable: 2,
       }),
     ]
 
     it('calculates the min, max and mean of the data and appends it to the matrix result array', async () => {
-      db.find.mockImplementationOnce(() => ({
-        toArray: () => sizeVariableData,
-      }))
-      db.find.mockImplementationOnce(() => ({
-        toArray: () => jumpVariableData,
-      }))
-      db.find.mockImplementationOnce(() => ({
-        toArray: () => [],
-      }))
+      await appDb.collection(collections.assessmentSubjectDayData).insertMany([
+        ...jumpVariableData,
+        ...sizeVariableData,
+      ])
 
       const dashboardProcessor = new DashboardDataProcessor(
         assessmentsFromConfig,
         config,
-        db
+        appDb,
       )
       const { matrixData } = await dashboardProcessor.calculateDashboardData()
 

--- a/server/data_processors/DashboardDataProcessor/index.js
+++ b/server/data_processors/DashboardDataProcessor/index.js
@@ -5,18 +5,19 @@ class DashboardDataProcessor {
   #configDataMap = new Map()
   #assessmentsFromConfig
 
-  constructor(assessmentsFromConfig, configuration, db) {
+  constructor(assessmentsFromConfig, configuration, subject, db) {
     this.#assessmentsFromConfig = assessmentsFromConfig
     this.configuration = configuration
+    this.subject = subject
     this.db = db
     this.matrixData = []
   }
 
   #dataFromAssessments = async () =>
     await Promise.all(
-      this.#assessmentsFromConfig.map(async ({ collection, assessment }) => {
+      this.#assessmentsFromConfig.map(async ({ assessment }) => {
         const data = await this.db.collection(collections.assessmentSubjectDayData)
-          .find({ collection })
+          .find({ assessment, subject: this.subject })
           .toArray()
 
         this.#configDataMap.set(assessment, data)

--- a/server/data_processors/DashboardDataProcessor/index.js
+++ b/server/data_processors/DashboardDataProcessor/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import CollectionsModel from '../../models/CollectionsModel'
+import { collections } from '../../utils/mongoCollections'
 
 class DashboardDataProcessor {
   #configDataMap = new Map()
@@ -15,7 +15,9 @@ class DashboardDataProcessor {
   #dataFromAssessments = async () =>
     await Promise.all(
       this.#assessmentsFromConfig.map(async ({ collection, assessment }) => {
-        const data = await CollectionsModel.all(this.db, collection)
+        const data = await this.db.collection(collections.assessmentSubjectDayData)
+          .find({ collection })
+          .toArray()
 
         this.#configDataMap.set(assessment, data)
       })

--- a/server/models/StudiesModel/index.js
+++ b/server/models/StudiesModel/index.js
@@ -3,7 +3,7 @@ import { collections } from '../../utils/mongoCollections'
 const study = 'study'
 
 const StudiesModel = {
-  all: async (db) => await db.collection(collections.toc).distinct(study),
+  all: async (db) => await db.collection(collections.assessmentSubjectRange).distinct(study),
 }
 
 export default StudiesModel

--- a/server/services/DashboardService/index.js
+++ b/server/services/DashboardService/index.js
@@ -64,6 +64,7 @@ class DashboardService {
     const dashboardDataProcessor = new DashboardDataProcessor(
       assessmentsFromConfig,
       this.configuration,
+      this.subject,
       this.db
     )
     const { matrixData } = await dashboardDataProcessor.calculateDashboardData()

--- a/server/utils/mongoCollections.js
+++ b/server/utils/mongoCollections.js
@@ -4,4 +4,6 @@ export const collections = {
   metadata: 'metadata',
   toc: 'toc',
   users: 'users',
+  assessmentSubjectDayData: 'assessmentSubjectDayData',
+  assessmentSubjectRange: 'assessmentSubjectRange',
 }


### PR DESCRIPTION
Tickets: 
- https://github.com/orgs/AMP-SCZ/projects/2/views/3?pane=issue&itemId=37850197
- https://github.com/orgs/AMP-SCZ/projects/2/views/3?pane=issue&itemId=37850716
- https://github.com/orgs/AMP-SCZ/projects/2/views/3?pane=issue&itemId=37850525

This turned out to be way easier than I thought, which I guess is better than the reverse. Dropping the connection to `dpdata` but leaving the `dataDb` variable in place is ugly but worked great, and the additional migrations were a straight copy from one db to the other. `DashboardDataProcessor` looks complicated, but once I worked out that most of it was happening in memory updating the query was fairly simple. Still lots of work that can be done around end-to-end testing and performance improvements, but this should get us to the first step of having a sensible data structure in Mongo.