### PR TITLE
Jvc/add image init workflow

### DIFF
--- a/.github/workflows/bootstrap_cdk.yaml
+++ b/.github/workflows/bootstrap_cdk.yaml
@@ -1,0 +1,24 @@
+name: Deploy Infrastructure
+on:
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Deploy with AWS CDK
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    if: ${{ startsWith(vars.ROLE_ARN, 'arn:aws:iam') }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Configure AWS credentials from Test account
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.ROLE_ARN }}
+        aws-region: us-east-1
+    - name: Install dependencies
+      run: npm ci --legacy-peer-deps
+    - name: Bootstrap CDK
+      run: npm run bootstrap

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -1,0 +1,44 @@
+name: Build Images
+on:
+  workflow_dispatch:
+jobs:
+  build-and-push:
+    name: Build and Push Docker Dependencies
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    if: ${{ startsWith(vars.ROLE_ARN, 'arn:aws:iam') }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ROLE_ARN }}
+          role-session-name: dpdash-ghactions-session
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push dpdash docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: dpdash
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Build, tag, and push mongo docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: mongo
+          IMAGE_TAG: '5.0.21'
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy_infrastructure.yaml
+++ b/.github/workflows/deploy_infrastructure.yaml
@@ -21,4 +21,5 @@ jobs:
     - name: Install dependencies
       run: npm ci --legacy-peer-deps
     - name: Deploy Dev
-      run: DEV_CERT_ARN=${{ vars.DEV_CERT_ARN }} EMAIL_DOMAIN=${{ vars.EMAIL_DOMAIN }} npm run deploy -- --require-approval never
+      run: DEV_CERT_ARN=${{ vars.DEV_CERT_ARN }} BASE_DOMAIN=${{ vars.BASE_DOMAIN }} npm run deploy -- --require-approval never
+BASE_DOMAIN=dpdash.l.org npm run deploy

--- a/AWS_SETUP.md
+++ b/AWS_SETUP.md
@@ -116,7 +116,7 @@ Navigate to your Github repository and select the Settings tab. Open the "Secret
 
 Create 2 variables:
 1. Create the variable ROLE_ARN with a value of the ARN of your Role from Step 3.
-2. Create the variable EMAIL_DOMAIN with the root domain you will use to host the app (e.g. `dpdash.com`). If you use an outside DNS rather than Route53, this will be the domain used in Step 2.
+2. Create the variable BASE_DOMAIN with the root domain you will use to host the app (e.g. `dpdash.com`). If you use an outside DNS rather than Route53, this will be the domain used in Step 2.
 
 If you keep your domain outside of Route53, create one more variable:
 

--- a/cdk_lib/dpdash-cdk-stack.ts
+++ b/cdk_lib/dpdash-cdk-stack.ts
@@ -20,30 +20,30 @@ export class DpdashCdkStack extends cdk.Stack {
     let devCertArn
     let sesIdentityArn
 
-    if (!process.env.EMAIL_DOMAIN) {
-      throw new Error('EMAIL_DOMAIN environment variable is required');
+    if (!process.env.BASE_DOMAIN) {
+      throw new Error('BASE_DOMAIN environment variable is required');
     }
 
     if (process.env.DEV_CERT_ARN) {
       devCertArn = process.env.DEV_CERT_ARN;
-      sesIdentityArn = `aws:arn:ses:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identity/${process.env.EMAIL_DOMAIN}}`
+      sesIdentityArn = `aws:arn:ses:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identity/${process.env.BASE_DOMAIN}}`
     } else {
       const hostedZone = new route53.PublicHostedZone(this, `${APP_NAME}HostedZone`, {
-        zoneName: process.env.EMAIL_DOMAIN,
+        zoneName: process.env.BASE_DOMAIN,
       });
 
       const devHostedZone = new route53.PublicHostedZone(this, `${APP_NAME}HostedZone`, {
-        zoneName: `staging.${process.env.EMAIL_DOMAIN}`,
+        zoneName: `staging.${process.env.BASE_DOMAIN}`,
       });
 
       const devCert = new certificate_manager.Certificate(this, `${APP_NAME}DevCertificate`, {
-        domainName: `staging.${process.env.EMAIL_DOMAIN}`,
+        domainName: `staging.${process.env.BASE_DOMAIN}`,
         validation: certificate_manager.CertificateValidation.fromDns(devHostedZone),
       });
 
       const identity = new ses.EmailIdentity(this, 'Identity', {
         identity: ses.Identity.publicHostedZone(hostedZone),
-        mailFromDomain: process.env.EMAIL_DOMAIN,
+        mailFromDomain: process.env.BASE_DOMAIN,
       });
 
       devCertArn = devCert.certificateArn;


### PR DESCRIPTION
This PR automates two steps of the README to avoid requiring local commands when Github Actions is available. I also threw in a variable name change for clarity, since EMAIL_DOMAIN is used for non-email purposes.