### PR TITLE
Set up a convention for forms in the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,7 @@
         "uuid": "^3.3.2",
         "whatwg-fetch": "^3.6.2",
         "winston": "^3.1.0",
-        "yup": "^0.32.9",
-        "zod": "^3.22.4"
+        "yup": "^0.32.9"
       },
       "devDependencies": {
         "@babel/cli": "^7.13.16",
@@ -19204,14 +19203,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   },
   "dependencies": {
@@ -34281,11 +34272,6 @@
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
-    },
-    "zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-ses": "^3.437.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@hookform/resolvers": "^3.3.2",
         "@mui/icons-material": "^5.14.15",
         "@mui/material": "^5.14.15",
         "aws-cdk-lib": "2.100.0",
@@ -52,7 +53,8 @@
         "uuid": "^3.3.2",
         "whatwg-fetch": "^3.6.2",
         "winston": "^3.1.0",
-        "yup": "^0.32.9"
+        "yup": "^0.32.9",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.13.16",
@@ -68,6 +70,7 @@
         "@babel/register": "^7.13.16",
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^29.5.5",
         "@types/node": "20.7.1",
         "aws-cdk": "^2.100.0",
@@ -4273,6 +4276,14 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6067,6 +6078,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -12072,33 +12096,6 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -19207,6 +19204,14 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -22735,6 +22740,12 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
+    "@hookform/resolvers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
+      "requires": {}
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -24074,6 +24085,13 @@
         "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -28812,6 +28830,17 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "https-proxy-agent": {
       "version": "5.0.1",
@@ -34252,6 +34281,11 @@
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
+    },
+    "zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@aws-sdk/client-ses": "^3.437.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@hookform/resolvers": "^3.3.2",
     "@mui/icons-material": "^5.14.15",
     "@mui/material": "^5.14.15",
     "aws-cdk-lib": "2.100.0",
@@ -78,7 +79,8 @@
     "uuid": "^3.3.2",
     "whatwg-fetch": "^3.6.2",
     "winston": "^3.1.0",
-    "yup": "^0.32.9"
+    "yup": "^0.32.9",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.16",
@@ -94,6 +96,7 @@
     "@babel/register": "^7.13.16",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
     "@types/node": "20.7.1",
     "aws-cdk": "^2.100.0",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
     "uuid": "^3.3.2",
     "whatwg-fetch": "^3.6.2",
     "winston": "^3.1.0",
-    "yup": "^0.32.9",
-    "zod": "^3.22.4"
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.16",

--- a/views/App.css
+++ b/views/App.css
@@ -1,4 +1,5 @@
 :root {
   --primary-light: #addbff;
   --primary-main: #2196f3;
+  --text-secondary: #054DA7;
 }

--- a/views/components/Sidebar/SidebarFooter.jsx
+++ b/views/components/Sidebar/SidebarFooter.jsx
@@ -26,7 +26,7 @@ const SidebarFooter = ({ user, onLogout }) => {
           sx={{ fontSize: fontSize[14], color: 'grey.A200' }}
           variant="subtitle1"
         >
-          Title {user.title}
+          {user.title}
         </Typography>
       </CardContent>
       <CardActions

--- a/views/components/Sidebar/SidebarLink.css
+++ b/views/components/Sidebar/SidebarLink.css
@@ -22,9 +22,9 @@
 }
 
 .SidebarLink_link-active .MuiListItemIcon-root {
-  color: #054DA7;
+  color: var(--text-secondary);
 }
 
 .SidebarLink_link-active .MuiListItemText-root {
-  color: #054DA7;
+  color: var(--text-secondary);
 }

--- a/views/forms/AdminForm/index.jsx
+++ b/views/forms/AdminForm/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Form from '../Form'
+
 import UserResetKeyFields from '../UserResetKeyFormFields'
 import AdminUsersTable from '../../components/VirtualTables/AdminUsersTable'
 import UserPriviligeFields from '../UserPriviligeFormFields'
@@ -25,7 +25,7 @@ const AdminForm = ({
   width,
 }) => {
   return (
-    <Form>
+    <form>
       <AdminUsersTable
         users={users}
         control={control}
@@ -53,7 +53,7 @@ const AdminForm = ({
         resetKey={resetKey}
         onClose={onClose}
       />
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/CharFilterForm/index.jsx
+++ b/views/forms/CharFilterForm/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button, List, ListItem, Typography, InputLabel } from '@mui/material'
-import Form from '../Form'
+
 import { FILTER_CATEGORIES, TRUE_STRING } from '../../../constants'
 import ControlledCheckbox from '../ControlledCheckbox'
 import ControlledReactSelect from '../ControlledReactSelect'
@@ -13,7 +13,7 @@ const ChartFilterForm = ({
   siteOptions,
 }) => {
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <div>
         {Object.keys(initialValues)
           .filter((key) => key !== 'sites')
@@ -63,7 +63,7 @@ const ChartFilterForm = ({
           Apply Filters
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/ChartForm.jsx
+++ b/views/forms/ChartForm.jsx
@@ -1,19 +1,18 @@
 import React from 'react'
 import Button from '@mui/material/Button'
 
-import Form from './Form'
 import BarChartFields from './BarChartFields'
 
 const ChartForm = ({ onSubmit, fields, control, ...rest }) => {
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <BarChartFields control={control} fields={fields} {...rest} />
       <div>
         <Button type="submit" variant="contained">
           Submit Form
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/ConfigForm/index.jsx
+++ b/views/forms/ConfigForm/index.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { Fab } from '@mui/material'
-import ContentAdd from '@mui/icons-material/Add'
-import Save from '@mui/icons-material/Save'
+import { ContentAdd, Save } from '@mui/icons-material'
+
 import ConfigFormFields from '../ConfigFields'
-import Form from '../Form'
 
 const ConfigForm = ({ onSubmit, onAddNewField, ...rest }) => {
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <ConfigFormFields {...rest} />
       <div>
         <Fab onClick={() => onAddNewField()}>
@@ -17,7 +16,7 @@ const ConfigForm = ({ onSubmit, onAddNewField, ...rest }) => {
           <Save />
         </Fab>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/Form.jsx
+++ b/views/forms/Form.jsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-const Form = ({ children, onSubmit }) => {
-  return <form onSubmit={onSubmit}>{children}</form>
-}
-
-export default Form

--- a/views/forms/RegisterForm/RegisterForm.test.jsx
+++ b/views/forms/RegisterForm/RegisterForm.test.jsx
@@ -2,15 +2,16 @@ import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import ResetPasswordForm from '.'
+import RegisterForm from '.'
 
-describe('Reset Password Form', () => {
+describe('Register Form', () => {
   const defaultProps = {
     initialValues: {
       username: '',
       password: '',
       confirmPassword: '',
-      reset_key: '',
+      fullName: '',
+      email: '',
     },
     onCancel: () => {},
     onSubmit: () => {},
@@ -19,12 +20,13 @@ describe('Reset Password Form', () => {
     usernameField: () => screen.getByRole('textbox', { name: 'Username' }),
     passwordField: () => screen.getByTestId('pw'),
     confirmPasswordField: () => screen.getByTestId('confirm-pw'),
-    resetKeyField: () => screen.getByRole('textbox', { name: 'Reset Key' }),
+    fullNameField: () => screen.getByRole('textbox', { name: 'Full Name' }),
+    emailField: () => screen.getByRole('textbox', { name: 'Email' }),
     cancelBtn: () => screen.getByText('Cancel'),
     submitBtn: () => screen.getByText('Submit'),
   }
   const renderForm = (props = defaultProps) => {
-    render(<ResetPasswordForm {...props} />)
+    render(<RegisterForm {...props} />)
   }
 
   test('calls the onSubmit prop when the form is submitted with valid data', async () => {
@@ -36,7 +38,8 @@ describe('Reset Password Form', () => {
     await user.type(elements.usernameField(), 'myUsername')
     await user.type(elements.passwordField(), 'myPassword')
     await user.type(elements.confirmPasswordField(), 'myPassword')
-    await user.type(elements.resetKeyField(), 'myResetKey')
+    await user.type(elements.fullNameField(), 'Joe Schmoe')
+    await user.type(elements.emailField(), 'joe@example.test')
     await user.click(elements.submitBtn())
 
     await waitFor(() =>
@@ -45,7 +48,8 @@ describe('Reset Password Form', () => {
           username: 'myUsername',
           password: 'myPassword',
           confirmPassword: 'myPassword',
-          reset_key: 'myResetKey',
+          fullName: 'Joe Schmoe',
+          email: 'joe@example.test',
         },
         expect.anything()
       )
@@ -61,7 +65,8 @@ describe('Reset Password Form', () => {
     await user.type(elements.usernameField(), 'myUsername')
     await user.type(elements.passwordField(), 'nope')
     await user.type(elements.confirmPasswordField(), 'nope')
-    await user.type(elements.resetKeyField(), 'myResetKey')
+    await user.type(elements.fullNameField(), 'Joe Schmoe')
+    await user.type(elements.emailField(), 'not-an-email')
     await user.click(elements.submitBtn())
 
     await waitFor(() =>
@@ -69,6 +74,7 @@ describe('Reset Password Form', () => {
         screen.getAllByText('String must contain at least 8 character(s)')
       ).toHaveLength(2)
     )
+    expect(screen.getByText('Invalid email')).toBeInTheDocument()
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
@@ -85,7 +91,8 @@ describe('Reset Password Form', () => {
       elements.confirmPasswordField(),
       'thisIsMyConfirmedPassword'
     )
-    await user.type(elements.resetKeyField(), 'myResetKey')
+    await user.type(elements.fullNameField(), 'Joe Schmoe')
+    await user.type(elements.emailField(), 'joe@example.test')
     await user.click(elements.submitBtn())
 
     await waitFor(() =>

--- a/views/forms/RegisterForm/RegisterForm.test.jsx
+++ b/views/forms/RegisterForm/RegisterForm.test.jsx
@@ -71,10 +71,10 @@ describe('Register Form', () => {
 
     await waitFor(() =>
       expect(
-        screen.getAllByText('String must contain at least 8 character(s)')
-      ).toHaveLength(2)
+        screen.getByText('password must be at least 8 characters')
+      ).toBeInTheDocument()
     )
-    expect(screen.getByText('Invalid email')).toBeInTheDocument()
+    expect(screen.getByText('email must be a valid email')).toBeInTheDocument()
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
@@ -96,7 +96,7 @@ describe('Register Form', () => {
     await user.click(elements.submitBtn())
 
     await waitFor(() =>
-      expect(screen.getAllByText('Passwords do not match')).toHaveLength(2)
+      expect(screen.getByText('passwords do not match')).toBeInTheDocument()
     )
 
     expect(onSubmit).not.toHaveBeenCalled()

--- a/views/forms/RegisterForm/index.jsx
+++ b/views/forms/RegisterForm/index.jsx
@@ -1,66 +1,97 @@
 import { Button } from '@mui/material'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 
 import TextInput from '../TextInput'
 
-const RegistrationForm = ({
-  onSubmit,
-  control,
-  errors,
-  navigate,
-  onInputChange,
-}) => {
+const schema = z
+  .object({
+    username: z.string(),
+    password: z.string().min(8),
+    confirmPassword: z.string().min(8),
+    fullName: z.string(),
+    email: z.string().email(),
+  })
+  .superRefine(({ confirmPassword, password }, ctx) => {
+    if (confirmPassword !== password) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+      })
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Passwords do not match',
+        path: ['password'],
+      })
+    }
+  })
+
+const RegistrationForm = ({ initialValues, onCancel, onSubmit }) => {
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm({
+    defaultValues: initialValues,
+    resolver: zodResolver(schema),
+  })
+
   return (
-    <form onSubmit={onSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <TextInput
         control={control}
-        name="username"
+        errors={errors.username}
+        fullWidth
         label="Username"
-        required={true}
         margin="normal"
+        name="username"
+        required={true}
       />
       <TextInput
         control={control}
-        type="password"
-        name="password"
+        errors={errors.password}
+        fullWidth
+        inputProps={{ 'data-testid': 'pw' }}
         label="Password"
-        required={true}
         margin="normal"
-        onChange={(e) => onInputChange(e)}
-        error={errors.password.error}
-        helperText={errors.password.message}
-      />
-      <TextInput
-        control={control}
+        name="password"
+        required={true}
         type="password"
-        name="confirmPassword"
+      />
+      <TextInput
+        control={control}
+        errors={errors.confirmPassword}
+        fullWidth
+        inputProps={{ 'data-testid': 'confirm-pw' }}
         label="Confirm Password"
-        onChange={(e) => onInputChange(e)}
-        required={true}
-        error={errors.confirmPassword.error}
-        helperText={errors.confirmPassword.message}
         margin="normal"
+        name="confirmPassword"
+        required={true}
+        type="password"
       />
       <TextInput
-        name="fullName"
+        control={control}
+        errors={errors.fullName}
+        fullWidth
         label="Full Name"
-        control={control}
-        required={true}
         margin="normal"
-        onChange={(e) => onInputChange(e)}
+        name="fullName"
+        required={true}
       />
       <TextInput
-        name="email"
-        label="Email"
         control={control}
-        required={true}
+        errors={errors.email}
+        fullWidth
+        label="Email"
         margin="normal"
-        onChange={(e) => onInputChange(e)}
-        error={errors.email.error}
-        helperText={errors.email.message}
+        name="email"
+        required={true}
       />
 
       <div>
-        <Button color="primary" onClick={() => navigate(`/login`)}>
+        <Button color="primary" onClick={() => onCancel()}>
           Cancel
         </Button>
         <Button variant="outlined" type="submit">

--- a/views/forms/RegisterForm/index.jsx
+++ b/views/forms/RegisterForm/index.jsx
@@ -1,32 +1,19 @@
 import { Button } from '@mui/material'
 import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
 
 import TextInput from '../TextInput'
 
-const schema = z
-  .object({
-    username: z.string(),
-    password: z.string().min(8),
-    confirmPassword: z.string().min(8),
-    fullName: z.string(),
-    email: z.string().email(),
-  })
-  .superRefine(({ confirmPassword, password }, ctx) => {
-    if (confirmPassword !== password) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Passwords do not match',
-        path: ['confirmPassword'],
-      })
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Passwords do not match',
-        path: ['password'],
-      })
-    }
-  })
+const schema = yup.object({
+  username: yup.string().required(),
+  password: yup.string().required().min(8),
+  confirmPassword: yup
+    .string()
+    .oneOf([yup.ref('password'), null], 'passwords do not match'),
+  fullName: yup.string().required(),
+  email: yup.string().required().email(),
+})
 
 const RegistrationForm = ({ initialValues, onCancel, onSubmit }) => {
   const {
@@ -35,7 +22,7 @@ const RegistrationForm = ({ initialValues, onCancel, onSubmit }) => {
     formState: { errors },
   } = useForm({
     defaultValues: initialValues,
-    resolver: zodResolver(schema),
+    resolver: yupResolver(schema),
   })
 
   return (

--- a/views/forms/RegisterForm/index.jsx
+++ b/views/forms/RegisterForm/index.jsx
@@ -1,6 +1,6 @@
-import Form from '../Form'
-import TextInput from '../TextInput'
 import { Button } from '@mui/material'
+
+import TextInput from '../TextInput'
 
 const RegistrationForm = ({
   onSubmit,
@@ -10,7 +10,7 @@ const RegistrationForm = ({
   onInputChange,
 }) => {
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <TextInput
         control={control}
         name="username"
@@ -67,7 +67,7 @@ const RegistrationForm = ({
           Submit
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/ResetPasswordForm/ResetPasswordForm.test.jsx
+++ b/views/forms/ResetPasswordForm/ResetPasswordForm.test.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import ResetPasswordForm from '.'
+
+describe('Reset Password Form', () => {
+  const defaultProps = {
+    initialValues: {
+      username: '',
+      password: '',
+      confirmPassword: '',
+      reset_key: '',
+    },
+    onCancel: () => {},
+    onSubmit: () => {},
+  }
+  const elements = {
+    usernameField: () => screen.getByRole('textbox', { name: 'Username' }),
+    passwordField: () => screen.getByTestId('pw'),
+    confirmPasswordField: () => screen.getByTestId('confirm-pw'),
+    resetKeyField: () => screen.getByRole('textbox', { name: 'Reset Key' }),
+    cancelBtn: () => screen.getByText('Cancel'),
+    submitBtn: () => screen.getByText('Submit'),
+  }
+  const renderForm = (props = defaultProps) => {
+    render(<ResetPasswordForm {...props} />)
+  }
+
+  test('calls the onSubmit prop when the form is submitted with valid data', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.type(elements.usernameField(), 'myUsername')
+    await user.type(elements.passwordField(), 'myPassword')
+    await user.type(elements.confirmPasswordField(), 'myPassword')
+    await user.type(elements.resetKeyField(), 'myResetKey')
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          username: 'myUsername',
+          password: 'myPassword',
+          confirmPassword: 'myPassword',
+          reset_key: 'myResetKey',
+        },
+        expect.anything()
+      )
+    )
+  })
+
+  test('displays errors and does not submit the form with invalid data', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.type(elements.usernameField(), 'myUsername')
+    await user.type(elements.passwordField(), 'nope')
+    await user.type(elements.confirmPasswordField(), 'nope')
+    await user.type(elements.resetKeyField(), 'myResetKey')
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('String must contain at least 8 character(s)')
+      ).toHaveLength(2)
+    )
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  test('displays errors and does not submit the form with unmatched passwords', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.type(elements.usernameField(), 'myUsername')
+    await user.type(elements.passwordField(), 'thisIsMyPassword')
+    await user.type(
+      elements.confirmPasswordField(),
+      'thisIsMyConfirmedPassword'
+    )
+    await user.type(elements.resetKeyField(), 'myResetKey')
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(screen.getAllByText('Passwords do not match')).toHaveLength(2)
+    )
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/views/forms/ResetPasswordForm/ResetPasswordForm.test.jsx
+++ b/views/forms/ResetPasswordForm/ResetPasswordForm.test.jsx
@@ -66,8 +66,8 @@ describe('Reset Password Form', () => {
 
     await waitFor(() =>
       expect(
-        screen.getAllByText('String must contain at least 8 character(s)')
-      ).toHaveLength(2)
+        screen.getByText('password must be at least 8 characters')
+      ).toBeInTheDocument()
     )
 
     expect(onSubmit).not.toHaveBeenCalled()
@@ -89,7 +89,7 @@ describe('Reset Password Form', () => {
     await user.click(elements.submitBtn())
 
     await waitFor(() =>
-      expect(screen.getAllByText('Passwords do not match')).toHaveLength(2)
+      expect(screen.getByText('passwords do not match')).toBeInTheDocument()
     )
 
     expect(onSubmit).not.toHaveBeenCalled()

--- a/views/forms/ResetPasswordForm/index.jsx
+++ b/views/forms/ResetPasswordForm/index.jsx
@@ -1,6 +1,6 @@
-import Form from '../Form'
-import TextInput from '../TextInput'
 import { Button } from '@mui/material'
+
+import TextInput from '../TextInput'
 
 const ResetPasswordForm = ({
   onSubmit,
@@ -10,7 +10,7 @@ const ResetPasswordForm = ({
   onInputChange,
 }) => {
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <TextInput
         control={control}
         name="username"
@@ -56,7 +56,7 @@ const ResetPasswordForm = ({
           Submit
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/ResetPasswordForm/index.jsx
+++ b/views/forms/ResetPasswordForm/index.jsx
@@ -1,31 +1,18 @@
 import { Button } from '@mui/material'
 import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
 
 import TextInput from '../TextInput'
 
-const schema = z
-  .object({
-    username: z.string(),
-    password: z.string().min(8),
-    confirmPassword: z.string().min(8),
-    reset_key: z.string(),
-  })
-  .superRefine(({ confirmPassword, password }, ctx) => {
-    if (confirmPassword !== password) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Passwords do not match',
-        path: ['confirmPassword'],
-      })
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Passwords do not match',
-        path: ['password'],
-      })
-    }
-  })
+const schema = yup.object({
+  username: yup.string().required(),
+  password: yup.string().required().min(8),
+  confirmPassword: yup
+    .string()
+    .oneOf([yup.ref('password'), null], 'passwords do not match'),
+  reset_key: yup.string().required(),
+})
 
 const ResetPasswordForm = ({ initialValues, onCancel, onSubmit }) => {
   const {
@@ -34,7 +21,7 @@ const ResetPasswordForm = ({ initialValues, onCancel, onSubmit }) => {
     formState: { errors },
   } = useForm({
     defaultValues: initialValues,
-    resolver: zodResolver(schema),
+    resolver: yupResolver(schema),
   })
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/views/forms/ResetPasswordForm/index.jsx
+++ b/views/forms/ResetPasswordForm/index.jsx
@@ -1,18 +1,47 @@
 import { Button } from '@mui/material'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 
 import TextInput from '../TextInput'
 
-const ResetPasswordForm = ({
-  onSubmit,
-  control,
-  errors,
-  navigate,
-  onInputChange,
-}) => {
+const schema = z
+  .object({
+    username: z.string(),
+    password: z.string().min(8),
+    confirmPassword: z.string().min(8),
+    reset_key: z.string(),
+  })
+  .superRefine(({ confirmPassword, password }, ctx) => {
+    if (confirmPassword !== password) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+      })
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Passwords do not match',
+        path: ['password'],
+      })
+    }
+  })
+
+const ResetPasswordForm = ({ initialValues, onCancel, onSubmit }) => {
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm({
+    defaultValues: initialValues,
+    resolver: zodResolver(schema),
+  })
   return (
-    <form onSubmit={onSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <TextInput
         control={control}
+        errors={errors.username}
+        fullWidth
         name="username"
         label="Username"
         required={true}
@@ -20,36 +49,38 @@ const ResetPasswordForm = ({
       />
       <TextInput
         control={control}
+        errors={errors.password}
+        fullWidth
+        inputProps={{ 'data-testid': 'pw' }}
         name="password"
         label="Password"
         type="password"
         required={true}
         margin="normal"
-        onChange={(e) => onInputChange(e)}
-        error={errors.password.error}
-        helperText={errors.password.message}
       />
       <TextInput
         control={control}
+        errors={errors.confirmPassword}
+        fullWidth
+        inputProps={{ 'data-testid': 'confirm-pw' }}
         name="confirmPassword"
         type="password"
         label="Confirm Password"
-        onChange={(e) => onInputChange(e)}
-        error={errors.confirmPassword.error}
-        helperText={errors.confirmPassword.message}
         required={true}
         margin="normal"
       />
       <TextInput
-        name="reset_key"
-        label="Reset Key"
         control={control}
-        required={true}
+        errors={errors.reset_key}
+        fullWidth
+        label="Reset Key"
         margin="normal"
+        name="reset_key"
+        required={true}
       />
 
       <div>
-        <Button color="primary" onClick={() => navigate(`/login`)}>
+        <Button color="primary" onClick={onCancel}>
           Cancel
         </Button>
         <Button variant="outlined" type="submit">

--- a/views/forms/ResetPasswordForm/index.jsx
+++ b/views/forms/ResetPasswordForm/index.jsx
@@ -80,7 +80,7 @@ const ResetPasswordForm = ({ initialValues, onCancel, onSubmit }) => {
       />
 
       <div>
-        <Button color="primary" onClick={onCancel}>
+        <Button color="primary" onClick={() => onCancel()}>
           Cancel
         </Button>
         <Button variant="outlined" type="submit">

--- a/views/forms/ShareForm/index.jsx
+++ b/views/forms/ShareForm/index.jsx
@@ -7,8 +7,8 @@ import {
   DialogActions,
   Typography,
 } from '@mui/material'
+
 import ControlledReactSelect from '../ControlledReactSelect'
-import Form from '../Form'
 
 const ShareForm = ({ control, onClose, onSubmit, open, options, title }) => {
   return (
@@ -17,7 +17,7 @@ const ShareForm = ({ control, onClose, onSubmit, open, options, title }) => {
         <Typography variant="title">{title}</Typography>
       </DialogTitle>
       <DialogContent>
-        <Form onSubmit={onSubmit}>
+        <form onSubmit={onSubmit}>
           <ControlledReactSelect
             isMulti={true}
             control={control}
@@ -31,7 +31,7 @@ const ShareForm = ({ control, onClose, onSubmit, open, options, title }) => {
               Submit
             </Button>
           </DialogActions>
-        </Form>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/views/forms/SignInForm/SignInForm.css
+++ b/views/forms/SignInForm/SignInForm.css
@@ -1,5 +1,5 @@
 .SignInForm_submitBtnContainer {
-  padding-top: 16px;
+  margin-top: 8px;
 }
 .SignInForm_button {
   border-radius: 8px;

--- a/views/forms/SignInForm/SignInForm.test.jsx
+++ b/views/forms/SignInForm/SignInForm.test.jsx
@@ -1,24 +1,52 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
-import LoginForm from '.'
-import FormProviderFixture from '../../../test/FormProviderFixture'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
-describe('Login Form', () => {
-  beforeEach(() => {
-    render(<LoginForm />, { wrapper: FormProviderFixture })
+import SignInForm from '.'
+
+describe('Sign In Form', () => {
+  const defaultProps = {
+    initialValues: {
+      username: '',
+      password: '',
+    },
+    onSubmit: () => {},
+  }
+  const elements = {
+    usernameField: () => screen.getByRole('textbox', { name: 'Username' }),
+    passwordField: () => screen.getByTestId('pw'),
+    submitBtn: () => screen.getByText('Sign in'),
+  }
+  const renderForm = (props = defaultProps) => {
+    render(<SignInForm {...props} />)
+  }
+
+  test('renders the text inputs and submit button', () => {
+    renderForm()
+
+    expect(elements.usernameField()).toBeInTheDocument()
+    expect(elements.passwordField()).toBeInTheDocument()
+    expect(elements.submitBtn()).toBeInTheDocument()
   })
 
-  test('renders the text inputs', () => {
-    const usernameField = screen.getByLabelText('username')
-    const passwordField = screen.getByLabelText('password')
+  test('calls the onSubmit prop when the form is submitted', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
 
-    expect(usernameField).toBeInTheDocument()
-    expect(passwordField).toBeInTheDocument()
-  })
+    renderForm(props)
+    await user.type(elements.usernameField(), 'myUsername')
+    await user.type(elements.passwordField(), 'myPassword')
+    await user.click(elements.submitBtn())
 
-  test('renders the Sign In button', () => {
-    const signInButton = screen.getByText('Sign in')
-
-    expect(signInButton).toBeInTheDocument()
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          username: 'myUsername',
+          password: 'myPassword',
+        },
+        expect.anything()
+      )
+    )
   })
 })

--- a/views/forms/SignInForm/index.jsx
+++ b/views/forms/SignInForm/index.jsx
@@ -1,27 +1,35 @@
 import React from 'react'
-import TextInput from '../TextInput'
 import { Button } from '@mui/material'
-import Form from '../Form'
+import { useForm } from 'react-hook-form'
+
+import TextInput from '../TextInput'
 import './SignInForm.css'
 
-const SignInForm = ({ onSubmit }) => {
+const SignInForm = ({ initialValues, onSubmit }) => {
+  const { control, handleSubmit } = useForm({
+    defaultValues: initialValues,
+  })
+
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <TextInput
+        control={control}
         name="username"
         label="Username"
         required={true}
         fullWidth={true}
         margin="normal"
-        variant="outlined"
+        type="text"
       />
       <TextInput
-        name="password"
-        type="password"
+        control={control}
+        fullWidth={true}
+        inputProps={{ 'data-testid': 'pw' }}
         label="Password"
-        required={true}
         margin="normal"
-        variant="outlined"
+        name="password"
+        required={true}
+        type="password"
       />
       <div className="SignInForm_submitBtnContainer">
         <Button
@@ -36,7 +44,7 @@ const SignInForm = ({ onSubmit }) => {
           Sign in
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/TextInput/index.jsx
+++ b/views/forms/TextInput/index.jsx
@@ -15,7 +15,7 @@ const TextInput = (props) => {
       InputLabelProps={{ shrink: true }}
       inputProps={props.inputProps}
       label={props.label}
-      margin="normal"
+      margin={props.margin || 'normal'}
       required={props.required}
       type={props.type}
       {...field}

--- a/views/forms/TextInput/index.jsx
+++ b/views/forms/TextInput/index.jsx
@@ -1,30 +1,24 @@
 import React from 'react'
 import TextField from '@mui/material/TextField'
-import { Controller, useFormContext } from 'react-hook-form'
+import { useController } from 'react-hook-form'
 
 const TextInput = (props) => {
-  const { name, onChange, ...rest } = props
-  const { control } = useFormContext()
+  const { errors } = props
+  const { field } = useController(props)
 
   return (
-    <Controller
-      name={name}
-      control={control}
-      render={({ field }) => (
-        <TextField
-          aria-label={name}
-          fullWidth={true}
-          margin="dense"
-          {...field}
-          {...rest}
-          inputRef={field.ref}
-          onChange={(e) => {
-            field.onChange(e)
-
-            if (onChange) onChange(e)
-          }}
-        />
-      )}
+    <TextField
+      aria-invalid={!!errors ? 'true' : 'false'}
+      aria-label={props.label}
+      fullWidth={props.fullWidth}
+      helperText={errors?.message}
+      InputLabelProps={{ shrink: true }}
+      inputProps={props.inputProps}
+      label={props.label}
+      margin="normal"
+      required={props.required}
+      type={props.type}
+      {...field}
     />
   )
 }

--- a/views/forms/UserProfileForm/UserProfileForm.test.jsx
+++ b/views/forms/UserProfileForm/UserProfileForm.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import UserProfileForm from '.'
+
+describe('User Profile Form', () => {
+  const pngFile = new File(['hello'], 'hello.png', { type: 'image/png' })
+  const defaultProps = {
+    initialValues: {
+      icon: '',
+      display_name: '',
+      mail: '',
+      title: '',
+      department: '',
+      company: '',
+    },
+    onCancel: () => {},
+    onSubmit: () => {},
+  }
+  const elements = {
+    displayNameField: () => screen.getByRole('textbox', { name: 'Full Name' }),
+    emailField: () => screen.getByRole('textbox', { name: 'Email' }),
+    titleField: () => screen.getByRole('textbox', { name: 'Title' }),
+    departmentField: () => screen.getByRole('textbox', { name: 'Department' }),
+    companyField: () => screen.getByRole('textbox', { name: 'Company' }),
+    iconField: () => screen.getByTestId('icon-input'),
+    submitBtn: () => screen.getByText('Save'),
+  }
+  const renderForm = (props = defaultProps) => {
+    render(<UserProfileForm {...props} />)
+  }
+
+  test('calls the onSubmit prop when the form is submitted with valid data', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.type(elements.displayNameField(), 'My Full Name')
+    await user.type(elements.emailField(), 'myEmail@example.test')
+    await user.type(elements.titleField(), 'My Title')
+    await user.type(elements.departmentField(), 'My Department')
+    await user.type(elements.companyField(), 'My Company')
+    await user.upload(elements.iconField(), pngFile)
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          display_name: 'My Full Name',
+          mail: 'myEmail@example.test',
+          title: 'My Title',
+          department: 'My Department',
+          company: 'My Company',
+          icon: expect.stringContaining('data:image/png;base64'),
+        },
+        expect.anything()
+      )
+    )
+  })
+
+  test('displays errors and does not submit the form with invalid data', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.type(elements.emailField(), 'not-an-email')
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(screen.getByText('mail must be a valid email')).toBeInTheDocument()
+    )
+    expect(
+      screen.getByText('display_name is a required field')
+    ).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/views/forms/UserProfileForm/index.jsx
+++ b/views/forms/UserProfileForm/index.jsx
@@ -1,12 +1,12 @@
-import Form from '../Form'
 import { Button, Tooltip } from '@mui/material'
-import TextInput from '../TextInput'
-import { EMAIL_REGEX } from '../../../constants'
 import { Controller } from 'react-hook-form'
+
+import { EMAIL_REGEX } from '../../../constants'
+import TextInput from '../TextInput'
 
 const UserProfileForm = ({ control, onSubmit, setUser, user }) => {
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <Controller
         control={control}
         name="icon"
@@ -80,7 +80,7 @@ const UserProfileForm = ({ control, onSubmit, setUser, user }) => {
           Save
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/views/forms/UserProfileForm/index.jsx
+++ b/views/forms/UserProfileForm/index.jsx
@@ -1,86 +1,116 @@
-import { Button, Tooltip } from '@mui/material'
-import { Controller } from 'react-hook-form'
+import React, { useRef } from 'react'
+import { Button } from '@mui/material'
+import { Controller, useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
 
 import { EMAIL_REGEX } from '../../../constants'
 import TextInput from '../TextInput'
 
-const UserProfileForm = ({ control, onSubmit, setUser, user }) => {
+const schema = yup.object({
+  company: yup.string(),
+  department: yup.string(),
+  display_name: yup.string().required(),
+  icon: yup.string(),
+  mail: yup.string().email().required(),
+  title: yup.string(),
+})
+
+const UserProfileForm = ({ initialValues, onSubmit }) => {
+  const profileImageRef = useRef()
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+    watch,
+  } = useForm({
+    defaultValues: initialValues,
+    resolver: yupResolver(schema),
+  })
+
   return (
-    <form onSubmit={onSubmit}>
-      <Controller
-        control={control}
-        name="icon"
-        render={({ field: { value, onChange, ...field } }) => {
-          return (
-            <div>
-              <input
-                accept="image/*"
-                id="icon"
-                multiple
-                type="file"
-                {...field}
-                value={value?.fileName}
-                onChange={(event) => {
-                  const { files } = event.target
+    <>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          control={control}
+          name="icon"
+          render={({ field }) => {
+            return (
+              <div>
+                <input
+                  accept="image/*"
+                  data-testid="icon-input"
+                  id="icon"
+                  multiple
+                  type="file"
+                  {...field}
+                  value={field.value?.fileName}
+                  onChange={(event) => {
+                    const { files } = event.target
 
-                  if (files[0]) {
-                    const reader = new FileReader()
+                    if (files[0]) {
+                      const reader = new FileReader()
 
-                    reader.readAsDataURL(files[0])
-                    reader.onload = (e) => {
-                      setUser({ ...user, icon: e.target.result })
-                      onChange(e.target.result)
+                      reader.readAsDataURL(files[0])
+                      reader.onload = (e) => {
+                        field.onChange(e.target.result)
+                      }
                     }
-                  }
-                }}
-              />
-              <label htmlFor="icon">
-                <span>
-                  <Tooltip title="Edit Profile Photo"></Tooltip>
-                </span>
-              </label>
-            </div>
-          )
-        }}
+                  }}
+                />
+                <label htmlFor="icon">Edit Profile Photo</label>
+              </div>
+            )
+          }}
+        />
+        <TextInput
+          control={control}
+          errors={errors.display_name}
+          label="Full Name"
+          name="display_name"
+          fullWidth={true}
+        />
+        <TextInput
+          control={control}
+          errors={errors.mail}
+          label="Email"
+          pattern={EMAIL_REGEX}
+          name="mail"
+          fullWidth={true}
+        />
+        <TextInput
+          control={control}
+          errors={errors.title}
+          label="Title"
+          name="title"
+          fullWidth={true}
+        />
+        <TextInput
+          control={control}
+          errors={errors.department}
+          label="Department"
+          name="department"
+          fullWidth={true}
+        />
+        <TextInput
+          control={control}
+          errors={errors.company}
+          label="Company"
+          name="company"
+          fullWidth={true}
+        />
+        <div>
+          <Button variant="outlined" type="submit">
+            Save
+          </Button>
+        </div>
+      </form>
+      <img
+        ref={profileImageRef}
+        src={watch('icon')}
+        style={{ height: 200, width: 200, objectFit: 'scale-down' }}
       />
-      <TextInput
-        control={control}
-        label="Full Name"
-        name="display_name"
-        fullWidth={true}
-      />
-      <TextInput
-        control={control}
-        label="Email"
-        type="email"
-        pattern={EMAIL_REGEX}
-        name="mail"
-        fullWidth={true}
-      />
-      <TextInput
-        control={control}
-        label="Title"
-        name="title"
-        fullWidth={true}
-      />
-      <TextInput
-        control={control}
-        label="Department"
-        name="department"
-        fullWidth={true}
-      />
-      <TextInput
-        control={control}
-        label="Company"
-        name="company"
-        fullWidth={true}
-      />
-      <div>
-        <Button variant="outlined" type="submit">
-          Save
-        </Button>
-      </div>
-    </form>
+    </>
   )
 }
 

--- a/views/layouts/HeroLayout/index.jsx
+++ b/views/layouts/HeroLayout/index.jsx
@@ -11,7 +11,10 @@ const HeroLayout = () => {
     <Box className="HeroLayout_container">
       <Box className="HeroLayout_main">
         <HeroCard />
-        <Outlet />
+
+        <Box sx={{ width: '458px', boxShadow: 5, px: '64px', py: '50px' }}>
+          <Outlet />
+        </Box>
       </Box>
       <HeroFooter />
     </Box>

--- a/views/pages/AccountPage.jsx
+++ b/views/pages/AccountPage.jsx
@@ -1,20 +1,14 @@
-import React, { useRef } from 'react'
-import { useForm } from 'react-hook-form'
+import React from 'react'
 import { useOutletContext } from 'react-router-dom'
 
 import api from '../api'
 import UserProfileForm from '../forms/UserProfileForm'
 
 const AccountPage = () => {
-  const canvasRef = useRef()
-  const profileImageRef = useRef()
   const { user, setUser, setNotification } = useOutletContext()
   const { icon, display_name, mail, title, department, company } = user
-  const { handleSubmit, control, watch } = useForm({
-    defaultValues: { icon, display_name, mail, title, department, company },
-  })
 
-  const handleFormSubmit = async (userProfileValues) => {
+  const onSubmit = async (userProfileValues) => {
     try {
       const updatedUser = await api.users.update(user.uid, {
         ...user,
@@ -34,42 +28,11 @@ const AccountPage = () => {
     }
   }
 
-  const scaleDownImage = () => {
-    const image = profileImageRef.current
-    const canvas = canvasRef.current
-    const ctx = canvas.getContext('2d')
-    const x = 0
-    const y = 0
-    let sx = 0
-    let sy = (image.naturalHeight - image.naturalWidth) / 2
-    let swidth = image.naturalWidth
-    let sheight = image.naturalWidth
-
-    if (image.naturalHeight < image.naturalWidth) {
-      sy = 0
-      sx = (image.naturalWidth - image.naturalHeight) / 2
-      swidth = image.naturalHeight
-      sheight = image.naturalHeight
-    }
-
-    canvas.height = 200
-    canvas.width = 200
-
-    ctx.drawImage(image, sx, sy, swidth, sheight, x, y, 200, 200)
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
-  }
-
   return (
-    <div>
-      <UserProfileForm
-        control={control}
-        onSubmit={handleSubmit(handleFormSubmit)}
-        user={user}
-        setUser={setUser}
-      />
-      <img ref={profileImageRef} onLoad={scaleDownImage} src={watch('icon')} />
-      <canvas ref={canvasRef} />
-    </div>
+    <UserProfileForm
+      initialValues={{ icon, display_name, mail, title, department, company }}
+      onSubmit={onSubmit}
+    />
   )
 }
 

--- a/views/pages/AccountPage.jsx
+++ b/views/pages/AccountPage.jsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react'
-import classnames from 'classnames'
 import { useForm } from 'react-hook-form'
 import { useOutletContext } from 'react-router-dom'
 

--- a/views/pages/AdminPage.jsx
+++ b/views/pages/AdminPage.jsx
@@ -3,6 +3,7 @@ import { useForm, useFieldArray } from 'react-hook-form'
 import { useOutletContext } from 'react-router-dom'
 import NoSsr from '@mui/material/NoSsr'
 import Select from 'react-select'
+
 import { UsersModel, StudiesModel } from '../models'
 import { components } from '../forms/ControlledReactSelect/components'
 import api from '../api'

--- a/views/pages/RegisterPage.jsx
+++ b/views/pages/RegisterPage.jsx
@@ -28,7 +28,7 @@ const RegisterPage = () => {
   return (
     <>
       <Typography variant="h4">Welcome to DPdash!</Typography>
-      <Typography variant="body1" color="textSecondary">
+      <Typography variant="body1" color="text.secondary">
         Please create your DPdash account to continue.
       </Typography>
       <RegistrationForm

--- a/views/pages/RegisterPage.jsx
+++ b/views/pages/RegisterPage.jsx
@@ -1,62 +1,23 @@
-import React, { useState, useEffect, useContext } from 'react'
-import { useForm } from 'react-hook-form'
+import React, { useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Card, CardContent, CardMedia, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
+
 import RegistrationForm from '../forms/RegisterForm'
 import { NotificationContext } from '../contexts'
-import { MIN_WIDTH, VALIDATION_EMAIL_REGEX } from '../../constants'
 import api from '../api'
+import { routes } from '../routes/routes'
 
 const RegisterPage = () => {
   const [, setNotification] = useContext(NotificationContext)
-  const [errors, setErrors] = useState({
-    password: { error: false, message: '' },
-    email: { error: false, message: '' },
-    confirmPassword: { error: false, message: '' },
-  })
-  const { handleSubmit, control } = useForm({
-    defaultValues: {
-      username: '',
-      password: '',
-      confirmPassword: '',
-      email: '',
-      fullName: '',
-    },
-  })
   const navigate = useNavigate()
-  const handleFormSubmit = async (data) => {
+  const onSubmit = async (data) => {
     try {
-      if (data.password !== data.confirmPassword) {
-        setErrors({
-          ...errors,
-          password: { error: true, message: 'passwords do not match' },
-        })
-
-        return
-      } else {
-        setErrors({
-          ...errors,
-          password: { error: false, message: '' },
-        })
-      }
-
-      const isFormReadyToBeSubmitted = Object.values(errors).every(
-        (value) => value.error === false
-      )
-
-      if (isFormReadyToBeSubmitted) {
-        await api.auth.signup(data)
-        setNotification({
-          open: true,
-          message:
-            'Account has been created, please wait for an Admin to provide access.',
-        })
-      } else {
-        setNotification({
-          open: true,
-          message: 'There are still errors in your form.',
-        })
-      }
+      await api.auth.signup(data)
+      setNotification({
+        open: true,
+        message:
+          'Account has been created, please wait for an Admin to provide access.',
+      })
     } catch (error) {
       setNotification({
         open: true,
@@ -64,63 +25,24 @@ const RegisterPage = () => {
       })
     }
   }
-  const handleChange = (e) => {
-    const { name, value } = e.target
-
-    if (name === 'email') {
-      if (VALIDATION_EMAIL_REGEX.test(value)) {
-        setErrors({
-          ...errors,
-          email: { error: false, message: '' },
-        })
-      } else if (!VALIDATION_EMAIL_REGEX.test(value)) {
-        setErrors({
-          ...errors,
-          email: { error: true, message: 'incorrect email format' },
-        })
-      }
-    }
-    if (name === 'password' || name === 'confirmPassword') {
-      if (value.length < 8) {
-        setErrors({
-          ...errors,
-          [name]: {
-            error: true,
-            message: 'passwords must be a minimum of 8 characters',
-          },
-        })
-      } else {
-        setErrors({
-          ...errors,
-          [name]: { error: false, message: '' },
-        })
-      }
-    }
-  }
   return (
-    <div>
-      <Card>
-        <div>
-          <CardContent>
-            <Typography variant="title">Welcome to DPdash!</Typography>
-            <Typography variant="subheading" color="textSecondary">
-              Please create your DPdash account to continue.
-            </Typography>
-          </CardContent>
-          <div>
-            <div>
-              <RegistrationForm
-                control={control}
-                onSubmit={handleSubmit(handleFormSubmit)}
-                errors={errors}
-                navigate={navigate}
-                onInputChange={handleChange}
-              />
-            </div>
-          </div>
-        </div>
-      </Card>
-    </div>
+    <>
+      <Typography variant="h4">Welcome to DPdash!</Typography>
+      <Typography variant="body1" color="textSecondary">
+        Please create your DPdash account to continue.
+      </Typography>
+      <RegistrationForm
+        initialValues={{
+          username: '',
+          password: '',
+          confirmPassword: '',
+          email: '',
+          fullName: '',
+        }}
+        onCancel={() => navigate(routes.login)}
+        onSubmit={onSubmit}
+      />
+    </>
   )
 }
 

--- a/views/pages/ResetPasswordPage.jsx
+++ b/views/pages/ResetPasswordPage.jsx
@@ -26,7 +26,7 @@ const ResetPasswordPage = () => {
   }
 
   return (
-    <Box sx={{ width: '458px', boxShadow: 5, px: '64px', py: '50px' }}>
+    <>
       <Typography variant="body1">Reset your DPDash account</Typography>
 
       <ResetPasswordForm
@@ -39,7 +39,7 @@ const ResetPasswordPage = () => {
         onCancel={() => navigate(routes.login)}
         onSubmit={onSubmit}
       />
-    </Box>
+    </>
   )
 }
 

--- a/views/pages/ResetPasswordPage.jsx
+++ b/views/pages/ResetPasswordPage.jsx
@@ -1,11 +1,6 @@
 import React, { useState, useContext } from 'react'
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
-
-import Card from '@mui/material/Card'
-import CardContent from '@mui/material/CardContent'
-import CardMedia from '@mui/material/CardMedia'
-import Typography from '@mui/material/Typography'
+import { Box, Card, CardContent, Typography } from '@mui/material'
 
 import { routes } from '../routes/routes'
 import api from '../api'
@@ -14,104 +9,37 @@ import { NotificationContext } from '../contexts'
 
 const ResetPasswordPage = () => {
   const [, setNotification] = useContext(NotificationContext)
-  const [errors, setErrors] = useState({
-    password: { error: false, message: '' },
-    confirmPassword: { error: false, message: '' },
-  })
-  const { handleSubmit, control } = useForm({
-    defaultValues: {
-      username: '',
-      password: '',
-      confirmPassword: '',
-      reset_key: '',
-    },
-  })
   const navigate = useNavigate()
-  const handleFormSubmit = async (resetAttributes) => {
+  const onSubmit = async (resetAttributes) => {
     try {
-      if (resetAttributes.password !== resetAttributes.confirmPassword) {
-        setErrors({
-          ...errors,
-          password: { error: true, message: 'passwords do not match' },
-          confirmPassword: { error: true, message: 'passwords do not match' },
-        })
+      await api.auth.resetPassword(resetAttributes)
 
-        return
-      } else if (resetAttributes.password === resetAttributes.confirmPassword) {
-        setErrors({
-          ...errors,
-          password: { error: false, message: '' },
-          confirmPassword: { error: false, message: '' },
-        })
-      }
+      navigate(routes.login)
 
-      const isFormReadyToBeSubmitted = Object.values(errors).every(
-        (value) => value.error === false
-      )
-
-      if (isFormReadyToBeSubmitted) {
-        await api.auth.resetPassword(resetAttributes)
-
-        navigate(routes.login)
-
-        setNotification({
-          open: true,
-          message: 'Password has been updated successfully.',
-        })
-      } else {
-        setNotification({
-          open: true,
-          message: 'Please fix any errors in the form.',
-        })
-      }
+      setNotification({
+        open: true,
+        message: 'Password has been updated successfully.',
+      })
     } catch (error) {
       setNotification({ open: true, message: error.message })
     }
   }
-  const handleChange = (e) => {
-    const { name, value } = e.target
 
-    if (name === 'password' || name === 'confirmPassword') {
-      if (value.length < 8) {
-        setErrors({
-          ...errors,
-          [name]: {
-            error: true,
-            message: 'passwords must be a minimum of 8 characters',
-          },
-        })
-      } else {
-        setErrors({
-          ...errors,
-          [name]: { error: false, message: '' },
-        })
-      }
-    }
-  }
   return (
-    <div>
-      <Card>
-        <div>
-          <CardContent>
-            <Typography variant="title">Welcome to DPdash!</Typography>
-            <Typography variant="subheading" color="textSecondary">
-              Reset your DPdash account.
-            </Typography>
-          </CardContent>
-          <div>
-            <div>
-              <ResetPasswordForm
-                control={control}
-                onSubmit={handleSubmit(handleFormSubmit)}
-                errors={errors}
-                navigate={navigate}
-                onInputChange={handleChange}
-              />
-            </div>
-          </div>
-        </div>
-      </Card>
-    </div>
+    <Box sx={{ width: '458px', boxShadow: 5, px: '64px', py: '50px' }}>
+      <Typography variant="body1">Reset your DPDash account</Typography>
+
+      <ResetPasswordForm
+        initialValues={{
+          username: '',
+          password: '',
+          confirmPassword: '',
+          reset_key: '',
+        }}
+        onCancel={() => navigate(routes.login)}
+        onSubmit={onSubmit}
+      />
+    </Box>
   )
 }
 

--- a/views/pages/SignInPage/SignInPage.css
+++ b/views/pages/SignInPage/SignInPage.css
@@ -1,11 +1,6 @@
 .SignInPage_container {
   width: 458px;
-  height: 447px;
-  display: flex;
-  flex-direction: column;
-  padding-left: 64px;
-  padding-right: 64px;
-  padding-top: 50px;
+  padding: 50px 64px;
 }
 .SignInPageRegister_link {
   text-decoration: none;

--- a/views/pages/SignInPage/SignInPage.css
+++ b/views/pages/SignInPage/SignInPage.css
@@ -1,12 +1,9 @@
-.SignInPage_container {
-  width: 458px;
-  padding: 50px 64px;
-}
 .SignInPageRegister_link {
   text-decoration: none;
   padding-left: 6px;
   color: var(--primary-main);
 }
+
 .SignInPageResetPW_link {
   padding-top: 16px;
   text-decoration: none;

--- a/views/pages/SignInPage/index.jsx
+++ b/views/pages/SignInPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { Box, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
+
 import { routes } from '../../routes/routes'
 import api from '../../api'
 import { AuthContext, NotificationContext } from '../../contexts'
@@ -23,7 +24,7 @@ const SignInPage = () => {
   }
 
   return (
-    <Box className="SignInPage_container" sx={{ boxShadow: 5 }}>
+    <>
       <Typography variant="h4" gutterBottom={true}>
         Sign In
       </Typography>
@@ -44,7 +45,7 @@ const SignInPage = () => {
       >
         Request Password Assistance
       </Typography>
-    </Box>
+    </>
   )
 }
 

--- a/views/pages/SignInPage/index.jsx
+++ b/views/pages/SignInPage/index.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { useForm, FormProvider } from 'react-hook-form'
 import { Box, Typography } from '@mui/material'
 import { routes } from '../../routes/routes'
 import api from '../../api'
@@ -9,16 +8,10 @@ import SignInForm from '../../forms/SignInForm'
 import './SignInPage.css'
 
 const SignInPage = () => {
-  const methods = useForm({
-    defaultValues: {
-      username: '',
-      password: '',
-    },
-  })
   const navigate = useNavigate()
   const [, setUser] = useContext(AuthContext)
   const [, setNotification] = useContext(NotificationContext)
-  const handleFormSubmit = async (data) => {
+  const onSubmit = async (data) => {
     try {
       const user = await api.auth.login(data)
 
@@ -40,9 +33,10 @@ const SignInPage = () => {
           Sign Up
         </Link>
       </Typography>
-      <FormProvider {...methods}>
-        <SignInForm onSubmit={methods.handleSubmit(handleFormSubmit)} />
-      </FormProvider>
+      <SignInForm
+        initialValues={{ username: '', password: '' }}
+        onSubmit={onSubmit}
+      />
       <Typography
         component={Link}
         to={routes.resetpw}


### PR DESCRIPTION
This PR refactors some existing code for the purpose of establishing conventions for forms in the app. The diff aims to provide a clear separation between forms and pages or components that render forms. Before this change there was significant coupling between forms and pages, with form setup and validation happening in the page components. Some of the proposed conventions include:

**All forms take an "initialValues" prop**

This prop allows us to reuse the same form when editing or creating new resources. Though we might not have a case for editing some resources (yet, at least), having this convention makes our implementation extensible and provides consistency.

**All forms take an "onSubmit" prop that is called with valid form data**

This prop makes our page components simpler and more declarative, by telling the form component what to do with the data that is submitted in the form (make API requests, navigate to new pages, etc).

**Use Zod for form validation**

Instead of writing custom validation logic, let's rely on an existing form validation library that works well with react-hook-form.