### PR TITLE
use an MUI Autocomplete component for multi select

### DIFF
--- a/views/forms/ChartFilterForm/ChartFilterForm.test.jsx
+++ b/views/forms/ChartFilterForm/ChartFilterForm.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import ChartFilterForm from '.'
@@ -22,7 +22,10 @@ describe('Chart Filter Form', () => {
         { name: 'Female', value: 'false' },
         { name: 'Missing', value: 'false' },
       ],
-      sites: ['CA', 'LA'],
+      sites: [
+        { label: 'CA', value: 'CA' },
+        { label: 'LA', value: 'LA' },
+      ],
     },
     siteOptions: [
       { label: 'CA', value: 'CA' },
@@ -38,7 +41,7 @@ describe('Chart Filter Form', () => {
       screen.getByRole('checkbox', { name: 'chrcrit_part.1.value' }),
     includedExcludedMissing: () =>
       screen.getByRole('checkbox', { name: 'included_excluded.2.value' }),
-    siteSelect: () => screen.getByLabelText('Sites'),
+    siteSelect: () => screen.getByRole('combobox', { name: 'Sites' }),
     siteOptions: () => screen.getByRole('listbox'),
     submitBtn: () => screen.getByText('Apply Filters'),
   }
@@ -54,9 +57,10 @@ describe('Chart Filter Form', () => {
     renderForm(props)
     await user.click(elements.hcField())
     await user.click(elements.includedExcludedMissing())
-    await user.click(elements.siteSelect())
-    await user.click(within(elements.siteOptions()).getByText('CA'))
-    await user.click(within(elements.siteOptions()).getByText('MA'))
+    const siteSelect = elements.siteSelect()
+    await userEvent.type(siteSelect, '{backspace}')
+    await userEvent.type(siteSelect, 'm')
+    await userEvent.click(screen.getByText('MA'))
     await user.click(elements.submitBtn())
 
     await waitFor(() =>
@@ -77,7 +81,10 @@ describe('Chart Filter Form', () => {
             { name: 'Female', value: 'false' },
             { name: 'Missing', value: 'false' },
           ],
-          sites: ['LA', 'MA'],
+          sites: [
+            { label: 'CA', value: 'CA' },
+            { label: 'MA', value: 'MA' },
+          ],
         },
         expect.anything()
       )

--- a/views/forms/ChartFilterForm/ChartFilterForm.test.jsx
+++ b/views/forms/ChartFilterForm/ChartFilterForm.test.jsx
@@ -90,4 +90,25 @@ describe('Chart Filter Form', () => {
       )
     )
   })
+
+  test('does not call the onSubmit prop with no sites', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.click(elements.hcField())
+    await user.click(elements.includedExcludedMissing())
+    const siteSelect = elements.siteSelect()
+    await userEvent.type(siteSelect, '{backspace}')
+    await userEvent.type(siteSelect, '{backspace}')
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('You must select at least 1 site')
+      ).toBeInTheDocument()
+    )
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
 })

--- a/views/forms/ChartFilterForm/index.jsx
+++ b/views/forms/ChartFilterForm/index.jsx
@@ -1,14 +1,21 @@
 import React from 'react'
 import { useForm } from 'react-hook-form'
 import { Button, List, ListItem, Typography, InputLabel } from '@mui/material'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
 
 import { FILTER_CATEGORIES, TRUE_STRING } from '../../../constants'
 import ControlledCheckbox from '../ControlledCheckbox'
 import ControlledMultiSelect from '../ControlledMultiSelect'
 
+const schema = yup.object({
+  sites: yup.array().min(1, 'You must select at least 1 site'),
+})
+
 const ChartFilterForm = ({ initialValues, onSubmit, siteOptions }) => {
   const { handleSubmit, control } = useForm({
     defaultValues: initialValues,
+    resolver: yupResolver(schema),
   })
 
   return (

--- a/views/forms/ChartFilterForm/index.jsx
+++ b/views/forms/ChartFilterForm/index.jsx
@@ -48,15 +48,12 @@ const ChartFilterForm = ({ initialValues, onSubmit, siteOptions }) => {
           })}
       </div>
       <div>
-        <InputLabel id="sites-select" variant="subtitle2">
-          Sites
-        </InputLabel>
         <ControlledMultiSelect
-          labelId="sites-select"
+          label="Sites"
           name="sites"
           control={control}
           options={siteOptions}
-          placeholder="Select a site to view data"
+          placeholder="Select sites to view data"
           fullWidth
         />
       </div>

--- a/views/forms/ControlledMultiSelect/ControlledMultiSelect.test.jsx
+++ b/views/forms/ControlledMultiSelect/ControlledMultiSelect.test.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+
+import ControlledMultiSelect from '.'
+
+describe('Controlled Multi Select', () => {
+  const defaultComponentProps = {
+    label: 'Input label',
+    name: 'field_name',
+    options: [
+      { label: 'One', value: '1' },
+      { label: 'Two', value: '2' },
+      { label: 'Three', value: '3' },
+    ],
+  }
+  const defaultProps = {
+    initialValues: { field_name: [] },
+    onSubmit: () => {},
+    componentProps: defaultComponentProps,
+  }
+  const elements = {
+    autoComplete: () => screen.getByRole('combobox', { name: 'Input label' }),
+    submitBtn: () => screen.getByRole('button', { name: 'submit' }),
+  }
+  const FormWrapper = (props) => {
+    const { control, handleSubmit } = useForm({
+      defaultValues: props.initialValues,
+    })
+
+    return (
+      <form onSubmit={handleSubmit(props.onSubmit)}>
+        <ControlledMultiSelect control={control} {...props.componentProps} />
+
+        <input type="submit" value="submit" />
+      </form>
+    )
+  }
+  const renderComponent = (props = defaultProps) => {
+    render(<FormWrapper {...props} />)
+  }
+
+  test('allows selecting a new option', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderComponent(props)
+    const textbox = elements.autoComplete()
+    await userEvent.type(textbox, 'o')
+    await userEvent.click(await screen.findByText('One'))
+    await userEvent.type(textbox, 't')
+    await userEvent.click(await screen.findByText('Two'))
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          field_name: [
+            defaultComponentProps.options[0],
+            defaultComponentProps.options[1],
+          ],
+        },
+        expect.anything()
+      )
+    )
+  })
+
+  test('removing an existing option', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = {
+      ...defaultProps,
+      initialValues: {
+        field_name: [
+          defaultComponentProps.options[1],
+          defaultComponentProps.options[2],
+        ],
+      },
+      onSubmit,
+    }
+
+    renderComponent(props)
+    await userEvent.type(elements.autoComplete(), '{backspace}')
+    await user.click(elements.submitBtn())
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          field_name: [defaultComponentProps.options[1]],
+        },
+        expect.anything()
+      )
+    )
+  })
+})

--- a/views/forms/ControlledMultiSelect/index.jsx
+++ b/views/forms/ControlledMultiSelect/index.jsx
@@ -7,20 +7,20 @@ const ControlledMultiSelect = (props) => {
     <Controller
       name={props.name}
       control={props.control}
-      render={({ field }) => (
+      render={({ field, fieldState }) => (
         <Autocomplete
           id={props.name}
           fullWidth={props.fullWidth}
-          isOptionEqualToValue={(option, value) => {
-            return option.value === value.value
-          }}
+          isOptionEqualToValue={(option, value) => option.value === value.value}
           multiple
           onChange={(_, data) => field.onChange(data)}
           options={props.options}
           renderInput={(params) => (
             <TextField
               {...params}
+              aria-invalid={!!fieldState.error ? 'true' : 'false'}
               label={props.label}
+              helperText={fieldState.error?.message}
               placeholder={props.placeholder}
             />
           )}

--- a/views/forms/ControlledMultiSelect/index.jsx
+++ b/views/forms/ControlledMultiSelect/index.jsx
@@ -1,32 +1,31 @@
 import React from 'react'
 import { Controller } from 'react-hook-form'
-import Select from '@mui/material/Select'
-import { Box, Chip, MenuItem } from '@mui/material'
+import { Autocomplete, TextField } from '@mui/material'
 
-const ControlledMultiSelect = ({ name, control, options, ...rest }) => {
+const ControlledMultiSelect = (props) => {
   return (
     <Controller
-      name={name}
-      control={control}
+      name={props.name}
+      control={props.control}
       render={({ field }) => (
-        <Select
-          {...rest}
-          {...field}
+        <Autocomplete
+          id={props.name}
+          fullWidth={props.fullWidth}
+          isOptionEqualToValue={(option, value) => {
+            return option.value === value.value
+          }}
           multiple
-          renderValue={(selected) => (
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-              {selected.map((value) => (
-                <Chip key={value} label={value} />
-              ))}
-            </Box>
+          onChange={(_, data) => field.onChange(data)}
+          options={props.options}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={props.label}
+              placeholder={props.placeholder}
+            />
           )}
-        >
-          {options.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
+          value={field.value}
+        />
       )}
     />
   )

--- a/views/forms/TextInput/index.jsx
+++ b/views/forms/TextInput/index.jsx
@@ -18,6 +18,7 @@ const TextInput = (props) => {
       margin={props.margin || 'normal'}
       required={props.required}
       type={props.type}
+      placeholder={props.placeholder}
       {...field}
     />
   )

--- a/views/pages/ViewChartPage.jsx
+++ b/views/pages/ViewChartPage.jsx
@@ -18,26 +18,18 @@ import api from '../api'
 import StudiesModel from '../models/StudiesModel'
 
 const ViewChartPage = () => {
-  const { setNotification } = useOutletContext()
   const { search } = useLocation()
   const { chart_id } = useParams()
   const navigate = useNavigate()
   const [graph, setGraph] = useState(null)
   const onSubmit = async (formValues) => {
-    if (!formValues.sites.length) {
-      setNotification({
-        open: true,
-        message: 'Please select a site to view data',
-      })
-    } else {
-      const filters = {
-        ...formValues,
-        sites: formValues.sites.map((option) => option.value),
-      }
-      const newRoute = routes.viewChart(chart_id, { filters })
-
-      navigate(newRoute)
+    const filters = {
+      ...formValues,
+      sites: formValues.sites.map((option) => option.value),
     }
+    const newRoute = routes.viewChart(chart_id, { filters })
+
+    navigate(newRoute)
   }
   const fetchGraph = async (chart_id, filters) =>
     await api.charts.chartsData.show(chart_id, { filters })

--- a/views/pages/ViewChartPage.jsx
+++ b/views/pages/ViewChartPage.jsx
@@ -23,13 +23,17 @@ const ViewChartPage = () => {
   const { chart_id } = useParams()
   const navigate = useNavigate()
   const [graph, setGraph] = useState(null)
-  const onSubmit = async (filters) => {
-    if (!filters.sites.length) {
+  const onSubmit = async (formValues) => {
+    if (!formValues.sites.length) {
       setNotification({
         open: true,
         message: 'Please select a site to view data',
       })
     } else {
+      const filters = {
+        ...formValues,
+        sites: formValues.sites.map((option) => option.value),
+      }
       const newRoute = routes.viewChart(chart_id, { filters })
 
       navigate(newRoute)
@@ -53,6 +57,9 @@ const ViewChartPage = () => {
 
     return res
   }
+  const siteOptions = graph
+    ? StudiesModel.dropdownSelectOptions(graph.userSites)
+    : []
 
   useEffect(() => {
     const parsedQuery = qs.parse(search.replace(/^\?/, ''))
@@ -63,6 +70,7 @@ const ViewChartPage = () => {
   }, [chart_id, search])
 
   if (!graph) return <div>Loading...</div>
+
   return (
     <>
       {graph.description && (
@@ -78,9 +86,14 @@ const ViewChartPage = () => {
       )}
       <div>
         <ChartFilterForm
-          initialValues={graph.filters}
+          initialValues={{
+            ...graph.filters,
+            sites: siteOptions.filter((option) =>
+              graph.filters.sites.includes(option.value)
+            ),
+          }}
           onSubmit={onSubmit}
-          siteOptions={StudiesModel.dropdownSelectOptions(graph.userSites)}
+          siteOptions={siteOptions}
         />
       </div>
       <BarGraph graph={graph} />


### PR DESCRIPTION
This commit includes the changes necessary to use an MUI Autocomplete component for multi select instead of an MUI Select component. This is because the Autocomplete component allows typing to filter options.