### PR TITLE
Add charts table to dashboard

### DIFF
--- a/constants/theme.js
+++ b/constants/theme.js
@@ -47,6 +47,7 @@ export const fontSize = {
   12: '0.75rem',
   14: '0.875rem',
   18: '1.15rem',
+  20: '1.20rem',
 }
 
 export const lineHeight = {

--- a/test/PageRenderer.jsx
+++ b/test/PageRenderer.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthContext, NotificationContext } from '../views/contexts'
+
+const renderPage = (PageComponent, props = {}) =>
+  render(
+    <MemoryRouter>
+      <NotificationContext.Provider value={[{}, jest.fn()]}>
+        <AuthContext.Provider value={[{}, jest.fn()]}>
+          <PageComponent {...props} />
+        </AuthContext.Provider>
+      </NotificationContext.Provider>
+    </MemoryRouter>
+  )
+
+export default renderPage

--- a/views/hooks/useChartsList.jsx
+++ b/views/hooks/useChartsList.jsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import api from '../api'
+
+const NULL_CHART = {}
+
+export default function useChartsList() {
+  const { user, setNotification, users } = useOutletContext()
+  const [chartToShare, setChartToShare] = useState(NULL_CHART)
+  const [chartList, setChartList] = useState([])
+  const [usernames, setUsernames] = useState([])
+
+  const closeDialog = () => setChartToShare(NULL_CHART)
+  const onShare = (chart) => setChartToShare(chart)
+  const shareWithUsers = async (chart_id, sharedWith, options = {}) => {
+    try {
+      await api.charts.chartsShare.create(chart_id, sharedWith)
+
+      const updatedChart = { ...chartToShare, sharedWith }
+      const updatedChartList = chartList.map((chart) =>
+        chart._id === updatedChart._id ? updatedChart : chart
+      )
+
+      setChartList(updatedChartList)
+      options.closeDialog ? closeDialog() : setChartToShare(updatedChart)
+      setNotification({ open: true, message: 'Shared chart with user' })
+    } catch (error) {
+      setNotification({ open: true, message: error.message })
+    }
+  }
+  const onDelete = async (chart) => {
+    try {
+      await api.charts.chart.destroy(chart._id)
+
+      await loadCharts()
+    } catch (error) {
+      setNotification({ open: true, message: error.message })
+    }
+  }
+  const onDuplicate = async (chart) => {
+    try {
+      await api.charts.chartsDuplicate.create(chart._id)
+
+      await loadCharts()
+    } catch (error) {
+      setNotification({ open: true, message: error.message })
+    }
+  }
+  const loadCharts = async () => {
+    try {
+      const data = await api.charts.chart.index()
+
+      setChartList(data)
+    } catch (error) {
+      setNotification({ open: true, message: error.message })
+    }
+  }
+
+  useEffect(() => {
+    loadCharts()
+  }, [])
+
+  useEffect(() => {
+    const apiUsernames = users
+      .filter(({ uid }) => uid !== user.uid)
+      .map(({ uid }) => ({
+        value: uid,
+        label: uid,
+      }))
+
+    setUsernames(apiUsernames)
+  }, [users])
+
+  return {
+    charts: chartList,
+    chartToShare,
+    closeDialog,
+    onShare,
+    onDelete,
+    onDuplicate,
+    shareWithUsers,
+    user,
+    usernames,
+  }
+}

--- a/views/pages/AccountPage/index.jsx
+++ b/views/pages/AccountPage/index.jsx
@@ -13,7 +13,7 @@ import './AccountPage.css'
 
 const AccountPage = () => {
   const { user, setUser, setNotification } = useOutletContext()
-  const { display_name, icon, iconFileName, mail, title } = user
+  const { display_name, icon, iconFileName, mail, title, preferences } = user
   const iconFile =
     !!icon && !!iconFileName
       ? FileModel.fromDataURL(icon, iconFileName)
@@ -24,9 +24,9 @@ const AccountPage = () => {
       const { iconFile, ...formData } = userProfileValues
       const icon = iconFile ? await FileModel.toDataURL(iconFile) : ''
       const iconFileName = iconFile ? iconFile.name : ''
-
       const updatedUser = await api.users.update(user.uid, {
         ...formData,
+        preferences,
         icon,
         iconFileName,
       })

--- a/views/pages/ChartsPage.jsx
+++ b/views/pages/ChartsPage.jsx
@@ -1,80 +1,26 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { Box, Button } from '@mui/material'
 import { Link, useOutletContext } from 'react-router-dom'
 
-import api from '../api'
 import ChartsTable from '../tables/ChartsTable'
 import PageHeader from '../components/PageHeader'
 import ShareChart from '../components/ShareCharts'
 import { routes } from '../routes/routes'
 
-const NULL_CHART = {}
+import useChartsList from '../hooks/useChartsList'
 
 const ChartsPage = () => {
-  const { user, setNotification, users } = useOutletContext()
-  const [chartToShare, setChartToShare] = useState(NULL_CHART)
-  const [chartList, setChartList] = useState([])
-  const [usernames, setUsernames] = useState([])
-
-  const closeDialog = () => setChartToShare(NULL_CHART)
-  const onShare = (chart) => setChartToShare(chart)
-  const shareWithUsers = async (chart_id, sharedWith, options = {}) => {
-    try {
-      await api.charts.chartsShare.create(chart_id, sharedWith)
-
-      const updatedChart = { ...chartToShare, sharedWith }
-      const updatedChartList = chartList.map((chart) =>
-        chart._id === updatedChart._id ? updatedChart : chart
-      )
-
-      setChartList(updatedChartList)
-      options.closeDialog ? closeDialog() : setChartToShare(updatedChart)
-      setNotification({ open: true, message: 'Shared chart with user' })
-    } catch (error) {
-      setNotification({ open: true, message: error.message })
-    }
-  }
-  const onDelete = async (chart) => {
-    try {
-      await api.charts.chart.destroy(chart._id)
-
-      await loadCharts()
-    } catch (error) {
-      setNotification({ open: true, message: error.message })
-    }
-  }
-  const onDuplicate = async (chart) => {
-    try {
-      await api.charts.chartsDuplicate.create(chart._id)
-      await loadCharts()
-    } catch (error) {
-      setNotification({ open: true, message: error.message })
-    }
-  }
-  const loadCharts = async () => {
-    try {
-      const data = await api.charts.chart.index()
-
-      setChartList(data)
-    } catch (error) {
-      setNotification({ open: true, message: error.message })
-    }
-  }
-
-  useEffect(() => {
-    loadCharts()
-  }, [])
-
-  useEffect(() => {
-    const apiUsernames = users
-      .filter(({ uid }) => uid !== user.uid)
-      .map(({ uid }) => ({
-        value: uid,
-        label: uid,
-      }))
-
-    setUsernames(apiUsernames)
-  }, [users])
+  const { user } = useOutletContext()
+  const {
+    charts,
+    chartToShare,
+    closeDialog,
+    onShare,
+    onDelete,
+    onDuplicate,
+    shareWithUsers,
+    usernames,
+  } = useChartsList()
 
   return (
     <Box sx={{ p: '20px' }}>
@@ -94,7 +40,7 @@ const ChartsPage = () => {
       />
       <ChartsTable
         onShare={onShare}
-        charts={chartList}
+        charts={charts}
         onDelete={onDelete}
         onDuplicate={onDuplicate}
         user={user}

--- a/views/pages/DashboardPage/DashboardPage.css
+++ b/views/pages/DashboardPage/DashboardPage.css
@@ -1,0 +1,3 @@
+.DashboardPageSection {
+  padding-top: 56px;
+}

--- a/views/pages/DashboardPage/DashboardPageSectionHeader.jsx
+++ b/views/pages/DashboardPage/DashboardPageSectionHeader.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Typography } from '@mui/material'
+
+import { fontSize } from '../../../constants'
+
+const DashboardPageSectionHeader = ({ title, to }) => {
+  return (
+    <span>
+      <Typography
+        variant="body"
+        sx={{ fontSize: fontSize[20], fontWeight: 600, pr: '16px' }}
+      >
+        {title}
+      </Typography>
+      <Typography
+        component={Link}
+        to={to}
+        sx={{ fontSize: fontSize[12], color: 'text.primary' }}
+      >
+        View All
+      </Typography>
+    </span>
+  )
+}
+
+export default DashboardPageSectionHeader

--- a/views/pages/DashboardPage/DashboardPageSectionHeader.test.jsx
+++ b/views/pages/DashboardPage/DashboardPageSectionHeader.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import DashboardPageSectionHeader from './DashboardPageSectionHeader'
+
+describe('DashboardPageSectionHeader', () => {
+  it('renders a header with a title and a View All text with an href property', () => {
+    render(<DashboardPageSectionHeader to="/some-route" title="Section" />, {
+      wrapper: MemoryRouter,
+    })
+
+    const viewAll = screen.getByText('View All')
+    const title = screen.getByText('Section')
+
+    expect(title).toBeInTheDocument()
+    expect(viewAll).toHaveAttribute('href', '/some-route')
+  })
+})

--- a/views/pages/DashboardPage/index.jsx
+++ b/views/pages/DashboardPage/index.jsx
@@ -1,34 +1,71 @@
 import React from 'react'
+import { useOutletContext } from 'react-router-dom'
 import { Box } from '@mui/material'
 
 import ParticipantsTable from '../../tables/ParticipantsTable'
 import PageHeader from '../../components/PageHeader'
 import useParticipantsList from '../../hooks/useParticipantsList'
+import { routes } from '../../routes/routes'
+
+import ChartsTable from '../../tables/ChartsTable'
+import useChartsList from '../../hooks/useChartsList'
+import DashboardPageSectionHeader from './DashboardPageSectionHeader'
+import ShareChart from '../../components/ShareCharts'
+
+import './DashboardPage.css'
 
 const DashboardPage = () => {
+  const { user } = useOutletContext()
+  const { participants, onSort, onStar, sortBy, sortDirection } =
+    useParticipantsList()
   const {
-    participants,
-    onSort,
-    onStar,
-    sortBy,
-    sortDirection,
-  } = useParticipantsList()
+    charts,
+    chartToShare,
+    closeDialog,
+    onShare,
+    onDelete,
+    onDuplicate,
+    shareWithUsers,
+    usernames,
+  } = useChartsList()
 
   return (
     <Box sx={{ p: '20px' }}>
-      <PageHeader
-        title="Dashboard"
-      />
-
-      <ParticipantsTable
-        participants={participants}
-        onStar={onStar}
-        onSort={onSort}
-        sortProperty={sortBy}
-        sortDirection={sortDirection}
-        sortable
-        maxRows={5}
-      />
+      <PageHeader title="Dashboard" />
+      <section className="DashboardPageSection">
+        <DashboardPageSectionHeader
+          to={routes.participants}
+          title="Participants"
+        />
+        <ParticipantsTable
+          participants={participants}
+          onStar={onStar}
+          onSort={onSort}
+          sortProperty={sortBy}
+          sortDirection={sortDirection}
+          sortable
+          maxRows={5}
+        />
+      </section>
+      <section className="DashboardPageSection">
+        <DashboardPageSectionHeader to={routes.charts} title="Charts" />
+        <ChartsTable
+          charts={charts}
+          maxRows={3}
+          onDelete={onDelete}
+          onDuplicate={onDuplicate}
+          onShare={onShare}
+          user={user}
+        />
+      </section>
+      {!!chartToShare._id && (
+        <ShareChart
+          chart={chartToShare}
+          usernames={usernames}
+          handleChange={shareWithUsers}
+          handleClose={closeDialog}
+        />
+      )}
     </Box>
   )
 }

--- a/views/pages/ParticipantsPage.jsx
+++ b/views/pages/ParticipantsPage.jsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Box } from '@mui/material'
-import { useOutletContext } from 'react-router-dom'
 
 import ParticipantsTable from '../tables/ParticipantsTable'
-import api from '../api'
-import { SORT_DIRECTION } from '../../constants'
 import ParticipantsSearchForm from '../forms/ParticipantsSearchForm'
 import PageHeader from '../components/PageHeader'
 import useParticipantsList from '../hooks/useParticipantsList'
@@ -20,7 +17,7 @@ const ParticipantsPage = () => {
     participants,
     searchOptions,
   } = useParticipantsList()
-  
+
   return (
     <Box sx={{ p: '20px' }}>
       <PageHeader

--- a/views/tables/ChartsTable/ChartsTable.test.jsx
+++ b/views/tables/ChartsTable/ChartsTable.test.jsx
@@ -15,16 +15,23 @@ describe(ChartsTable, () => {
       title: 'first chart',
       updatedAt: '2023-06-28T15:43:23.789Z',
       owner: user.uid,
+      chartOwner: { display_name: 'John Johnson' },
     }),
     createChart({
       title: 'second chart',
       updatedAt: '2022-11-10T00:01:04.713Z',
       owner: 'foo',
+      chartOwner: {
+        display_name: 'Jane Janeson',
+      },
     }),
     createChart({
       title: 'third chart',
       updatedAt: '2022-10-11T16:33:46.485Z',
       owner: 'bar',
+      chartOwner: {
+        display_name: 'Jack Jackson',
+      },
     }),
   ]
   const defaultProps = {
@@ -71,7 +78,7 @@ describe(ChartsTable, () => {
       within(elements.tableRow(0)).getByText(charts[0].title)
     ).toBeInTheDocument()
     expect(
-      within(elements.tableRow(0)).getByText(charts[0].owner)
+      within(elements.tableRow(0)).getByText(charts[0].chartOwner.display_name)
     ).toBeInTheDocument()
     expect(
       within(elements.tableRow(0)).getByText(
@@ -83,7 +90,7 @@ describe(ChartsTable, () => {
       within(elements.tableRow(1)).getByText(charts[1].title)
     ).toBeInTheDocument()
     expect(
-      within(elements.tableRow(1)).getByText(charts[1].owner)
+      within(elements.tableRow(1)).getByText(charts[1].chartOwner.display_name)
     ).toBeInTheDocument()
     expect(
       within(elements.tableRow(1)).getByText(
@@ -95,7 +102,7 @@ describe(ChartsTable, () => {
       within(elements.tableRow(2)).getByText(charts[2].title)
     ).toBeInTheDocument()
     expect(
-      within(elements.tableRow(2)).getByText(charts[2].owner)
+      within(elements.tableRow(2)).getByText(charts[2].chartOwner.display_name)
     ).toBeInTheDocument()
     expect(
       within(elements.tableRow(2)).getByText(

--- a/views/tables/ChartsTable/index.jsx
+++ b/views/tables/ChartsTable/index.jsx
@@ -47,6 +47,8 @@ const ChartsTable = ({
   ]
   const cellRenderer = (chart, property) => {
     switch (property) {
+      case 'owner':
+        return chart['chartOwner'].display_name
       case 'title':
         const viewChart = routes.viewChart(chart._id)
 
@@ -100,7 +102,14 @@ const ChartsTable = ({
     }
   }
 
-  return <Table cellRenderer={cellRenderer} data={charts} headers={headers} maxRows={maxRows} />
+  return (
+    <Table
+      cellRenderer={cellRenderer}
+      data={charts}
+      headers={headers}
+      maxRows={maxRows}
+    />
+  )
 }
 
 export default ChartsTable

--- a/views/tables/Table/index.jsx
+++ b/views/tables/Table/index.jsx
@@ -45,7 +45,7 @@ const Table = (props) => {
     sortDirection,
     sortProperty,
     handleRequestSort,
-    maxRows
+    maxRows,
   } = props
 
   const rows = maxRows && data.length > maxRows ? data.slice(0, maxRows) : data


### PR DESCRIPTION
This pr adds the charts table to the dashboard, and it fixes a minor bug.

Bug: when saving editing a user, the preferences were being removed in the edit profile page.



<img width="718" alt="Screenshot 2023-11-29 at 9 25 48 AM" src="https://github.com/dptools/dpdash/assets/19805355/43b33f77-e175-438b-83bc-b77933dc288f">
