### PR TITLE
check that an admin with a set password exists when checking admin presence

### DIFF
--- a/server/models/UserModel/index.js
+++ b/server/models/UserModel/index.js
@@ -70,7 +70,7 @@ const UserModel = {
   hasAdmin: async (db) => {
     const userCt = await db
       .collection(collections.users)
-      .countDocuments({ role: "admin" })
+      .countDocuments({ role: "admin", password: { $ne: null } })
     return userCt !== 0
   },
   createFirstAdmin: async (db) => {


### PR DESCRIPTION
This PR allows us to resend emails when there's an issue with the admin initialization email. When this PR is deployed it will generate an email access error that Justin is going to grab for me from the logs.