### PR TITLE
Favorite Charts

### DIFF
--- a/jestServerConfig.js
+++ b/jestServerConfig.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '@shelf/jest-mongodb',
+  setupFilesAfterEnv: ['<rootDir>/jestServerSetup.js'],
 }

--- a/jestServerSetup.js
+++ b/jestServerSetup.js
@@ -1,0 +1,12 @@
+import { MongoClient } from 'mongodb'
+
+beforeAll(async () => {
+  global.MONGO_INSTANCE = await MongoClient.connect(global.__MONGO_URI__, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  })
+})
+
+afterAll(async () => {
+  await global.MONGO_INSTANCE.close()
+})

--- a/server/controllers/api/siteMetadataController/siteMetadataController.test.js
+++ b/server/controllers/api/siteMetadataController/siteMetadataController.test.js
@@ -1,4 +1,3 @@
-import { MongoClient, ObjectId } from 'mongodb'
 import SiteMetadataController from '.'
 import {
   createRequest,
@@ -6,28 +5,20 @@ import {
   createSiteMetadata,
 } from '../../../../test/fixtures'
 
-let connection
 let dataDb
 
 describe('siteMetadataController', () => {
   describe(SiteMetadataController.create, () => {
     describe('When new data is imported', () => {
-      beforeAll(async () => {
-        connection = await MongoClient.connect(global.__MONGO_URI__, {
-          useNewUrlParser: true,
-          useUnifiedTopology: true,
-        })
-
-        dataDb = await connection.db('dpdata')
+      beforeAll(() => {
+        dataDb = global.MONGO_INSTANCE.db('dpdata')
       })
+
       beforeEach(async () => {
         await dataDb.createCollection('metadata')
       })
       afterEach(async () => {
         await dataDb.collection('metadata').drop()
-      })
-      afterAll(async () => {
-        await connection.close()
       })
 
       it('creates new metadata document', async () => {

--- a/server/controllers/chartsController/index.js
+++ b/server/controllers/chartsController/index.js
@@ -35,14 +35,14 @@ const chartsController = {
     try {
       const chartList = []
       const { dataDb, appDb } = req.app.locals
-      const chartListCursor = await ChartsModel.index(dataDb, {
-        $or: [{ owner: req.user }, { sharedWith: req.user }, { public: true }],
-      })
+      const currentUser = await UserModel.findOne(appDb, { uid: req.user })
+      const chartListCursor = await ChartsModel.all(dataDb, currentUser)
 
       while (await chartListCursor.hasNext()) {
         const chart = await chartListCursor.next()
 
         chart.chartOwner = await UserModel.findOne(appDb, { uid: chart.owner })
+
         chartList.push(chart)
       }
 

--- a/server/controllers/usersController/index.js
+++ b/server/controllers/usersController/index.js
@@ -9,6 +9,7 @@ const UsersController = {
         company,
         department,
         display_name,
+        favoriteCharts,
         icon,
         iconFileName,
         mail,
@@ -19,11 +20,12 @@ const UsersController = {
         company: String(company),
         department: String(department),
         display_name: String(display_name),
-        mail: String(mail),
-        title: String(title),
+        favoriteCharts,
         icon: String(icon),
         iconFileName: String(iconFileName),
+        mail: String(mail),
         preferences,
+        title: String(title),
       })
 
       return res.status(200).json({ data: updatedUser })

--- a/server/models/UserModel/index.js
+++ b/server/models/UserModel/index.js
@@ -70,13 +70,13 @@ const UserModel = {
   hasAdmin: async (db) => {
     const userCt = await db
       .collection(collections.users)
-      .countDocuments({ role: "admin", password: { $ne: null } })
+      .countDocuments({ role: 'admin', password: { $ne: null } })
     return userCt !== 0
   },
   createFirstAdmin: async (db) => {
     if (await UserModel.hasAdmin(db)) {
       return
-    } 
+    }
 
     const reset_key = crypto.randomBytes(32).toString('hex')
 
@@ -96,25 +96,26 @@ const UserModel = {
     }
   },
   withDefaults: (overrides = {}) => ({
+    access: [],
+    account_expires: null,
+    bad_pwd_count: 0,
+    blocked: false,
+    company: '',
     display_name: '',
     title: '',
     department: '',
-    company: '',
-    mail: '',
-    member_of: '',
-    bad_pwd_count: 0,
-    lockout_time: 0,
-    last_logoff: Date.now(),
-    last_logon: Date.now(),
-    account_expires: null,
-    password: '',
-    ldap: false,
+    favoriteCharts: [],
     force_reset_pw: false,
-    realms: [''],
     icon: '',
     iconFileName: '',
-    access: [],
-    blocked: false,
+    last_logoff: Date.now(),
+    last_logon: Date.now(),
+    ldap: false,
+    lockout_time: 0,
+    mail: '',
+    member_of: '',
+    password: '',
+    realms: [''],
     role: 'member',
     ...overrides,
   }),

--- a/views/hooks/useChartsList.jsx
+++ b/views/hooks/useChartsList.jsx
@@ -5,7 +5,10 @@ import api from '../api'
 const NULL_CHART = {}
 
 export default function useChartsList() {
-  const { user, setNotification, users } = useOutletContext()
+  const { setNotification, setUser, user, users } = useOutletContext()
+  const { uid, favoriteCharts } = user
+  const favoriteChartsSet = new Set(favoriteCharts)
+
   const [chartToShare, setChartToShare] = useState(NULL_CHART)
   const [chartList, setChartList] = useState([])
   const [usernames, setUsernames] = useState([])
@@ -46,6 +49,26 @@ export default function useChartsList() {
       setNotification({ open: true, message: error.message })
     }
   }
+  const onFavorite = async (chart) => {
+    try {
+      const isChartInSet = favoriteChartsSet.has(chart._id)
+
+      isChartInSet
+        ? favoriteChartsSet.delete(chart._id)
+        : favoriteChartsSet.add(chart._id)
+
+      const updatedUser = await api.users.update(uid, {
+        ...user,
+        favoriteCharts: Array.from(favoriteChartsSet),
+      })
+
+      setUser(updatedUser)
+
+      await loadCharts()
+    } catch (error) {
+      setNotification({ open: true, message: error.message })
+    }
+  }
   const loadCharts = async () => {
     try {
       const data = await api.charts.chart.index()
@@ -75,6 +98,7 @@ export default function useChartsList() {
     charts: chartList,
     chartToShare,
     closeDialog,
+    onFavorite,
     onShare,
     onDelete,
     onDuplicate,

--- a/views/pages/ChartsPage.jsx
+++ b/views/pages/ChartsPage.jsx
@@ -15,9 +15,10 @@ const ChartsPage = () => {
     charts,
     chartToShare,
     closeDialog,
-    onShare,
     onDelete,
     onDuplicate,
+    onFavorite,
+    onShare,
     shareWithUsers,
     usernames,
   } = useChartsList()
@@ -39,10 +40,11 @@ const ChartsPage = () => {
         }
       />
       <ChartsTable
-        onShare={onShare}
         charts={charts}
         onDelete={onDelete}
         onDuplicate={onDuplicate}
+        onFavorite={onFavorite}
+        onShare={onShare}
         user={user}
       />
       {!!chartToShare._id && (

--- a/views/pages/DashboardPage/index.jsx
+++ b/views/pages/DashboardPage/index.jsx
@@ -22,9 +22,10 @@ const DashboardPage = () => {
     charts,
     chartToShare,
     closeDialog,
-    onShare,
     onDelete,
     onDuplicate,
+    onFavorite,
+    onShare,
     shareWithUsers,
     usernames,
   } = useChartsList()
@@ -38,13 +39,13 @@ const DashboardPage = () => {
           title="Participants"
         />
         <ParticipantsTable
-          participants={participants}
+          maxRows={5}
           onStar={onStar}
           onSort={onSort}
+          participants={participants}
           sortProperty={sortBy}
           sortDirection={sortDirection}
           sortable
-          maxRows={5}
         />
       </section>
       <section className="DashboardPageSection">
@@ -54,6 +55,7 @@ const DashboardPage = () => {
           maxRows={3}
           onDelete={onDelete}
           onDuplicate={onDuplicate}
+          onFavorite={onFavorite}
           onShare={onShare}
           user={user}
         />
@@ -61,9 +63,9 @@ const DashboardPage = () => {
       {!!chartToShare._id && (
         <ShareChart
           chart={chartToShare}
-          usernames={usernames}
           handleChange={shareWithUsers}
           handleClose={closeDialog}
+          usernames={usernames}
         />
       )}
     </Box>

--- a/views/tables/ChartsTable/index.jsx
+++ b/views/tables/ChartsTable/index.jsx
@@ -1,8 +1,15 @@
 import React from 'react'
-import { Typography, Avatar } from '@mui/material'
-import { Link } from 'react-router-dom'
-import { ContentCopy, Edit, Delete, Share } from '@mui/icons-material'
+import { Typography, Avatar, Checkbox } from '@mui/material'
+import {
+  Star,
+  StarBorder,
+  ContentCopy,
+  Edit,
+  Delete,
+  Share,
+} from '@mui/icons-material'
 import dayjs from 'dayjs'
+import { Link } from 'react-router-dom'
 
 import { routes } from '../../routes/routes'
 import Table from '../Table'
@@ -14,12 +21,13 @@ import './ChartsTable.css'
 export const DATE_FORMAT = 'MM/DD/YYYY'
 const ChartsTable = ({
   charts,
-  sortable,
+  maxRows,
   onDelete,
   onDuplicate,
+  onFavorite,
   onShare,
+  sortable,
   user,
-  maxRows,
 }) => {
   const headers = [
     {
@@ -38,41 +46,20 @@ const ChartsTable = ({
       sortable: !!sortable,
     },
     {
+      dataProperty: 'star',
+      label: '',
+      sortable: false,
+    },
+    {
       dataProperty: 'info',
       dataAlign: 'right',
       label: '',
       sortable: false,
     },
   ]
+
   const cellRenderer = (chart, property) => {
     switch (property) {
-      case 'owner':
-        return (
-          <div className="ChartsTable_Profile">
-            <Avatar
-              alt={chart['chartOwner'].display_name[0]}
-              src={UrlModel.sanitizeUrl(
-                String(chart['chartOwner'].icon).trim()
-              )}
-              sx={{ width: 24, height: 24 }}
-            />
-            <Typography sx={{ pl: '5px' }}>
-              {chart['chartOwner'].display_name}
-            </Typography>
-          </div>
-        )
-      case 'title':
-        const viewChart = routes.viewChart(chart._id)
-
-        return (
-          <Link className="Link--unstyled" to={viewChart}>
-            <Typography variant="body1" sx={{ color: 'text.primary' }}>
-              {chart[property]}
-            </Typography>
-          </Link>
-        )
-      case 'updatedAt':
-        return chart[property] ? dayjs(chart[property]).format(DATE_FORMAT) : ''
       case 'info':
         const chartOwnedByUser = ChartModel.isOwnedByUser(chart, user)
 
@@ -107,6 +94,49 @@ const ChartsTable = ({
             ]}
           />
         )
+      case 'owner':
+        return (
+          <div className="ChartsTable_Profile">
+            <Avatar
+              alt={chart['chartOwner'].display_name[0]}
+              src={UrlModel.sanitizeUrl(
+                String(chart['chartOwner'].icon).trim()
+              )}
+              sx={{ width: 24, height: 24 }}
+            />
+            <Typography sx={{ pl: '5px' }}>
+              {chart['chartOwner'].display_name}
+            </Typography>
+          </div>
+        )
+      case 'star':
+        return (
+          <Checkbox
+            name={chart._id}
+            disableRipple={true}
+            icon={<StarBorder sx={{ color: 'primary.dark' }} />}
+            checked={chart.favorite}
+            checkedIcon={<Star sx={{ color: 'primary.dark' }} />}
+            onChange={() => onFavorite(chart)}
+            sx={{
+              border: 1,
+              borderRadius: '8px',
+              borderColor: 'primary.light',
+            }}
+          />
+        )
+      case 'title':
+        const viewChart = routes.viewChart(chart._id)
+
+        return (
+          <Link className="Link--unstyled" to={viewChart}>
+            <Typography variant="body1" sx={{ color: 'text.primary' }}>
+              {chart[property]}
+            </Typography>
+          </Link>
+        )
+      case 'updatedAt':
+        return chart[property] ? dayjs(chart[property]).format(DATE_FORMAT) : ''
       default:
         return chart[property]
     }


### PR DESCRIPTION
closes #534 

This pr adds the feature to favorite a chart. 
We store a list of chart id's to the favoriteCharts property in the user document, the property is used to sort the charts by placing the user's favorites at the top. 
The charts query has been updated from find to an aggregate.
The tests have been updated to support a global mongodb instance.

<img width="1246" alt="Screenshot 2023-12-26 at 8 28 27 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/1cb10dcd-1c10-4436-87ac-87ee0b3fa795">

