### PR TITLE
Participants can filter by study and status

### DIFF
--- a/server/controllers/participantsController/index.js
+++ b/server/controllers/participantsController/index.js
@@ -15,6 +15,7 @@ const ParticipantsController = {
         user,
         parsedQueryParams
       )
+
       return res.status(200).json({ data: participants })
     } catch (error) {
       return res.status(400).json({ error: error.message })

--- a/server/models/ParticipantsModel/index.js
+++ b/server/models/ParticipantsModel/index.js
@@ -1,8 +1,9 @@
 import { collections } from '../../utils/mongoCollections'
 import { ASC } from '../../constants'
 
-const subjects = '$subjects'
-const subject = '$subject'
+const $subjects = '$subjects'
+const $subject = '$subject'
+const participant = 'participant'
 
 const ParticipantsModel = {
   index: async (db, user, queryParams) =>
@@ -16,13 +17,32 @@ const allParticipantsQuery = (user, queryParams) => {
   const { star, complete } = user.preferences
   const starred = star ? Object.values(star).flat() : []
   const completed = complete ? Object.values(complete).flat() : []
-  const { sortBy, sortDirection, searchSubjects } = queryParams
+  const { status, sortBy, sortDirection, searchSubjects, studies } = queryParams
   const direction = sortDirection === ASC ? 1 : -1
   const sort = { $sort: { star: -1, [sortBy]: direction } }
+  const studiesSet = new Set(studies?.length ? studies : user.access)
+
+  searchSubjects?.forEach((participant) =>
+    studiesSet.add(`${participant[0]}${participant[1]}`)
+  )
+
+  const studiesQuery = Array.from(studiesSet)
+
   const query = [
-    { $match: { study: { $in: user.access } } },
-    { $unwind: subjects },
-    { $replaceRoot: { newRoot: subjects } },
+    {
+      $match: {
+        $or: [
+          {
+            study: {
+              $in: studiesQuery,
+            },
+          },
+        ],
+      },
+    },
+
+    { $unwind: $subjects },
+    { $replaceRoot: { newRoot: $subjects } },
     {
       $project: {
         subject: 1,
@@ -30,30 +50,63 @@ const allParticipantsQuery = (user, queryParams) => {
         study: 1,
         synced: 1,
         star: {
-          $in: [subject, starred],
+          $in: [$subject, starred],
         },
         complete: {
-          $in: [subject, completed],
+          $in: [$subject, completed],
         },
+        Active: 1,
       },
     },
   ]
 
-  if (searchSubjects?.length)
-    query.push({
-      $match: {
-        $or: [
-          {
-            subject: {
-              $in: searchSubjects,
+  if (searchSubjects?.length) {
+    if (studies?.length) {
+      query.push({
+        $match: {
+          $or: [
+            {
+              study: {
+                $in: studies,
+              },
             },
+            {
+              subject: {
+                $in: searchSubjects,
+              },
+            },
+          ],
+        },
+      })
+    } else {
+      query.push({
+        $match: {
+          $or: [
+            {
+              subject: {
+                $in: searchSubjects,
+              },
+            },
+          ],
+        },
+      })
+    }
+  }
+
+  if (status) {
+    query.splice(1, 0, {
+      $project: {
+        subjects: {
+          $filter: {
+            input: $subjects,
+            as: participant,
+            cond: { $eq: ['$$participant.Active', +status] },
           },
-        ],
+        },
       },
     })
-
+  }
   query.push(sort)
-
   return query
 }
 

--- a/views/api/participants/index.js
+++ b/views/api/participants/index.js
@@ -3,7 +3,7 @@ import http from '../http'
 
 const participants = {
   all: async (queryParams) =>
-    http.get(apiRoutes.participants.index(queryParams)),
+    http.get(apiRoutes.participants.index, queryParams),
 }
 
 export default participants

--- a/views/components/PageHeader/index.jsx
+++ b/views/components/PageHeader/index.jsx
@@ -9,14 +9,21 @@ const PageHeader = (props) => {
         display: 'flex',
         gap: '16px',
         justifyContent: 'space-between',
-        alignItems: 'center',
+        flexDirection: { xs: 'column', lg: 'row' },
+        alignItems: { xs: 'left', lg: 'center' },
       }}
     >
       <Typography sx={{ fontWeight: 600, width: 192 }}>
         {props.title}
       </Typography>
 
-      <Box sx={{ flex: 1 }}>{props.form}</Box>
+      <Box
+        sx={{
+          flex: 1,
+        }}
+      >
+        {props.form}
+      </Box>
 
       {props.cta && <Box>{props.cta}</Box>}
     </Box>

--- a/views/components/SearchSelect/MenuWithFooterActions.jsx
+++ b/views/components/SearchSelect/MenuWithFooterActions.jsx
@@ -1,0 +1,17 @@
+import React, { forwardRef } from 'react'
+import { Paper } from '@mui/material'
+
+const MenuWithFooterActions = forwardRef(function MenuWithFooterActions(
+  { children, actions, searchInput, ...other },
+  ref
+) {
+  return (
+    <Paper ref={ref} {...other} sx={{ width: '400px' }}>
+      {searchInput}
+      {children}
+      {actions}
+    </Paper>
+  )
+})
+
+export default MenuWithFooterActions

--- a/views/components/SearchSelect/SearchInput.css
+++ b/views/components/SearchSelect/SearchInput.css
@@ -1,0 +1,9 @@
+.SearchInput {
+  padding: 10px;
+  position: sticky;
+  bottom: 0;
+  right: 0;
+  top: 0;
+  z-index: 100;
+  background-color: white;
+}

--- a/views/components/SearchSelect/SearchInput.jsx
+++ b/views/components/SearchSelect/SearchInput.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { TextField } from '@mui/material'
+import './SearchInput.css'
+
+const SearchInput = ({ handleSearch }) => (
+  <div className="SearchInput">
+    <TextField
+      label="Find category"
+      variant="standard"
+      key="categorySearch"
+      fullWidth
+      onChange={handleSearch}
+    />
+  </div>
+)
+
+export default SearchInput

--- a/views/components/SearchSelect/SearchSelect.test.jsx
+++ b/views/components/SearchSelect/SearchSelect.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import SearchSelect from '.'
+
+jest.mock('react-hook-form', () => ({
+  ...jest.requireActual('react-hook-form'),
+  useController: () => jest.fn().mockReturnValue({ field: {} }),
+  control: {},
+}))
+
+describe('Search Select', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const defaultProps = {
+    control: {},
+    options: [
+      { label: 'AA', value: 'AA' },
+      { label: 'BB', value: 'BB' },
+      { label: 'CC', value: 'CC' },
+    ],
+    actions: (
+      <div>
+        <button>Left</button>
+        <button>Right</button>
+      </div>
+    ),
+    name: 'search select',
+    formValues: { studies: ['BB'] },
+    label: 'search select',
+  }
+  const elements = {
+    searchSelect: () =>
+      screen.getByRole('combobox', { label: 'search select' }),
+  }
+  const renderElement = (props) => render(<SearchSelect {...props} />)
+
+  it('renders a dropdown menu with input and actions', async () => {
+    renderElement(defaultProps)
+
+    const searchSelect = elements.searchSelect()
+
+    await userEvent.click(searchSelect)
+
+    const searchSelectInput = await screen.findByLabelText('Find category')
+    const optionsPopupEl = await screen.findByRole('listbox')
+    const leftActionButton = await screen.findByText('Left')
+    const rightActionButton = await screen.findByText('Right')
+
+    expect(optionsPopupEl.childElementCount).toEqual(3)
+    expect(searchSelectInput).toBeInTheDocument()
+    expect(leftActionButton).toBeInTheDocument()
+    expect(rightActionButton).toBeInTheDocument()
+  })
+
+  it('filters the list of options based on search', async () => {
+    renderElement(defaultProps)
+
+    const searchSelect = elements.searchSelect()
+
+    await userEvent.click(searchSelect)
+
+    const searchSelectInput = await screen.findByLabelText('Find category')
+
+    await userEvent.type(searchSelectInput, 'c')
+    const optionsPopupEl = await screen.findByRole('listbox')
+
+    await waitFor(() => expect(optionsPopupEl.childElementCount).toEqual(1))
+  })
+
+  it('checks the checkbox when value is within formValues', async () => {
+    renderElement(defaultProps)
+
+    const searchSelect = elements.searchSelect()
+
+    await userEvent.click(searchSelect)
+
+    const unchecked = screen.getAllByTestId('CheckBoxOutlineBlankIcon')
+    const checked = screen.getAllByTestId('CheckBoxIcon')
+
+    expect(unchecked.length).toBe(2)
+    expect(checked.length).toBe(1)
+  })
+})

--- a/views/components/SearchSelect/index.jsx
+++ b/views/components/SearchSelect/index.jsx
@@ -1,0 +1,78 @@
+import React, { useState, useMemo } from 'react'
+import { Card, Checkbox, MenuItem, ListItemText } from '@mui/material/'
+import ControlledSelectInput from '../../forms/ControlledSelect'
+import MenuWithFooterActions from './MenuWithFooterActions'
+import SearchInput from './SearchInput'
+import { fontSize } from '../../../constants'
+
+const SearchSelect = ({
+  control,
+  options,
+  actions,
+  name,
+  formValues,
+  label,
+}) => {
+  const [search, setSearch] = useState('')
+  const displayedOptions = useMemo(() => {
+    const searchTerm = new RegExp(search, 'i')
+    return options.filter(({ value }) => searchTerm.test(value))
+  }, [search])
+
+  const handleSearch = (e) => setSearch(e.target.value)
+  const handleClose = () => setSearch('')
+
+  return (
+    <ControlledSelectInput
+      control={control}
+      name={name}
+      multiple
+      label={label}
+      defaultValue={[]}
+      sx={{ flexGrow: 1, flexBasis: 0 }}
+      SelectProps={{
+        renderValue: (selected) => selected.join(', '),
+        onClose: () => handleClose(),
+        multiple: true,
+        MenuProps: {
+          autoFocus: false,
+          MenuListProps: {
+            autoFocus: true,
+          },
+          PaperProps: {
+            component: MenuWithFooterActions,
+            searchInput: <SearchInput handleSearch={handleSearch} />,
+            actions: (
+              <Card
+                raised={0}
+                sx={{
+                  position: 'sticky',
+                  bottom: 0,
+                  right: 0,
+                  left: 0,
+                  pt: '30px',
+                }}
+              >
+                {actions}
+              </Card>
+            ),
+          },
+        },
+      }}
+    >
+      {displayedOptions.map(({ label, value }) => {
+        return (
+          <MenuItem key={value} value={value}>
+            <Checkbox
+              sx={{ color: 'black.A100' }}
+              checked={formValues.studies?.includes(value)}
+            />
+            <ListItemText primary={label} sx={{ fontSize: fontSize[16] }} />
+          </MenuItem>
+        )
+      })}
+    </ControlledSelectInput>
+  )
+}
+
+export default SearchSelect

--- a/views/forms/ChartsSearchForm/index.jsx
+++ b/views/forms/ChartsSearchForm/index.jsx
@@ -34,6 +34,7 @@ const ChartsSearchForm = ({ initialValues, onSubmit }) => {
           (e) => onSubmit({ [e.target.name]: e.target.value }),
           500
         )}
+        autoComplete="off"
       />
     </form>
   )

--- a/views/forms/ControlledSelect/index.jsx
+++ b/views/forms/ControlledSelect/index.jsx
@@ -1,20 +1,19 @@
-import { Select } from '@mui/material'
-import { Controller } from 'react-hook-form'
+import React from 'react'
+import { TextField } from '@mui/material'
+import { useController } from 'react-hook-form'
 
-const ControlledSelectInput = ({ name, control, value, ...rest }) => {
+const ControlledSelectInput = ({ control, value, name, sx, ...rest }) => {
+  const { field } = useController({ name, control })
+
   return (
-    <Controller
+    <TextField
+      {...rest}
+      {...field}
       name={name}
-      control={control}
-      render={({ field }) => (
-        <Select
-          {...field}
-          {...rest}
-          fullWidth
-          value={field.value.value || value}
-          onChange={(e) => field.onChange({ value: e.target.value })}
-        />
-      )}
+      select
+      value={field?.value || value}
+      label={rest.label}
+      sx={sx || {}}
     />
   )
 }

--- a/views/forms/MultiSelect/index.jsx
+++ b/views/forms/MultiSelect/index.jsx
@@ -1,47 +1,48 @@
-import { Autocomplete, Chip, TextField } from '@mui/material';
-import React from 'react';
+import { Autocomplete, Chip, TextField } from '@mui/material'
+import React from 'react'
 
 export const MultiSelect = (props) => {
-  const { field, fieldState } = props;
-  
+  const { field, fieldState } = props
+
   return (
-      <Autocomplete
-        id={props.name}
-        fullWidth={props.fullWidth}
-        getOptionDisabled={(option) => option.isFixed}
-        isOptionEqualToValue={(option, value) => option.value === value.value}
-        multiple
-        onChange={(_, data, reason) => props.onChange(data, reason, field)}
-        options={props.options}
-        renderTags={(tagValue, getTagProps) =>
-          tagValue.map((option, index) => (
-            <Chip
-              key={`${field}-chip-${index}`}
-              label={option.label}
-              {...getTagProps({ index })}
-              disabled={option.isFixed}
-            />
-          ))
-        }
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            aria-invalid={!!fieldState?.error ? 'true' : 'false'}
-            label={props.label}
-            helperText={fieldState?.error?.message}
-            InputProps={{
-              ...params.InputProps,
-              startAdornment: (
-                <>
-                  {props.startAdornment}
-                  {params.InputProps.startAdornment}
-                </>
-              ),
-            }}
-            placeholder={props.placeholder}
+    <Autocomplete
+      id={props.name}
+      fullWidth={props.fullWidth}
+      getOptionDisabled={(option) => option.isFixed}
+      isOptionEqualToValue={(option, value) => option.value === value.value}
+      multiple
+      onChange={(_, data, reason) => props.onChange(data, reason, field)}
+      options={props.options}
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            key={`${field}-chip-${index}`}
+            label={option.label}
+            {...getTagProps({ index })}
+            disabled={option.isFixed}
           />
-        )}
-        value={props.value || field.value}
-      />
+        ))
+      }
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          aria-invalid={!!fieldState?.error ? 'true' : 'false'}
+          label={props.label}
+          helperText={fieldState?.error?.message}
+          InputProps={{
+            ...params.InputProps,
+            startAdornment: (
+              <>
+                {props.startAdornment}
+                {params.InputProps.startAdornment}
+              </>
+            ),
+          }}
+          placeholder={props.placeholder}
+        />
+      )}
+      value={props.value || field.value}
+      sx={props.sx || {}}
+    />
   )
 }

--- a/views/forms/ParticipantsSearchForm/ParticipantsSearchForm.css
+++ b/views/forms/ParticipantsSearchForm/ParticipantsSearchForm.css
@@ -1,0 +1,12 @@
+.ParticipantsSearchForm {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+@media screen and (max-width: 1100px) {
+  .ParticipantsSearchForm {
+    flex-direction: column;
+    align-items: normal;
+  }
+}

--- a/views/forms/ParticipantsSearchForm/index.jsx
+++ b/views/forms/ParticipantsSearchForm/index.jsx
@@ -1,44 +1,99 @@
 import React, { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { InputAdornment } from '@mui/material'
-import SearchIcon from '@mui/icons-material/Search'
+import { InputAdornment, MenuItem, Button, CardActions } from '@mui/material'
+import { Search } from '@mui/icons-material'
 import * as yup from 'yup'
 
 import ControlledMultiSelect from '../ControlledMultiSelect'
+import ControlledSelectInput from '../ControlledSelect'
+import SearchSelect from '../../components/SearchSelect'
+
+import './ParticipantsSearchForm.css'
 
 const schema = yup.object({
   participants: yup.array(),
+  studies: yup.array(),
+  status: yup.string(),
 })
 
 const ParticipantsSearchForm = ({ initialValues, onSubmit, allOptions }) => {
-  const { handleSubmit, control, formState, watch } = useForm({
+  const { handleSubmit, control, watch, setValue, getValues } = useForm({
     defaultValues: initialValues,
     mode: 'onChange',
     resolver: yupResolver(schema),
   })
-  const data = watch()
+  const formValues = getValues()
+
+  const handleClear = () => setValue('studies', [])
+  const handleSelectAll = () =>
+    setValue(
+      'studies',
+      allOptions.studies.map(({ value }) => value)
+    )
 
   useEffect(() => {
-    if (formState.isValid && !formState.isValidating) {
-      onSubmit(data)
-    }
-  }, [data, formState])
+    const subscription = watch((value) => onSubmit(value))
 
+    return () => subscription.unsubscribe()
+  }, [watch])
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <ControlledMultiSelect
-        name="participants"
-        control={control}
-        options={allOptions}
-        placeholder="Search participants you'd like to view"
-        startAdornment={
-          <InputAdornment position="start">
-            <SearchIcon />
-          </InputAdornment>
-        }
-        fullWidth
-      />
+      <div className="ParticipantsSearchForm">
+        <ControlledMultiSelect
+          name="participants"
+          control={control}
+          options={allOptions.participants}
+          placeholder="Search participants you'd like to view"
+          startAdornment={
+            <InputAdornment position="start">
+              <Search />
+            </InputAdornment>
+          }
+          sx={{ flexBasis: 1, flexGrow: 5 }}
+        />
+        <SearchSelect
+          options={allOptions.studies}
+          control={control}
+          formValues={formValues}
+          name="studies"
+          label="Study"
+          getValues={getValues}
+          actions={
+            <CardActions
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr',
+              }}
+            >
+              <Button color="primary" fullWidth onClick={handleClear}>
+                CLEAR
+              </Button>
+              <Button
+                color="primary"
+                fullWidth
+                onClick={handleSelectAll}
+                sx={{ gridColumnStart: 4, gridColumnEnd: 6 }}
+              >
+                SELECT ALL
+              </Button>
+            </CardActions>
+          }
+        />
+        <ControlledSelectInput
+          control={control}
+          name="status"
+          defaultValue={undefined}
+          sx={{ flexGrow: 1, flexBasis: 0 }}
+          label="Status"
+        >
+          <MenuItem value={undefined} key={'All'}>
+            All
+          </MenuItem>
+          <MenuItem value={1}>Active</MenuItem>
+          <MenuItem value={0}>Inactive</MenuItem>
+        </ControlledSelectInput>
+      </div>
     </form>
   )
 }

--- a/views/forms/TextInput/index.jsx
+++ b/views/forms/TextInput/index.jsx
@@ -17,7 +17,7 @@ const TextInput = (props) => {
       label={props.label}
       margin={props.margin || 'normal'}
       required={props.required}
-      type={props.type}
+      type={props.type || 'text'}
       placeholder={props.placeholder}
       sx={props.sx}
       size={props.size}

--- a/views/models/UserConfigModel/index.js
+++ b/views/models/UserConfigModel/index.js
@@ -1,7 +1,4 @@
-const defaultColorValue = {
-  value: 221,
-  label: ['#a6cee3', '#1f78b4', '#b2df8a', '#33a02c', '#fb9a99'],
-}
+const defaultColorValue = 221
 const UserConfigModel = {
   defaultConfigValues: {
     category: '',
@@ -20,80 +17,67 @@ const UserConfigModel = {
     public: false,
     ...overrides,
   }),
-  processNewConfig: async (formValues, colors, owner) => {
-    try {
-      const config = {
-        0: formValues.config.map(({ min, max, color, ...rest }) => {
-          return {
-            color: colors.find(({ value }) => value === color.value).label,
-            range: [min, max],
-            ...rest,
-          }
-        }),
-      }
-
-      return {
-        config,
-        name: formValues.configName,
-        owner,
-        type: formValues.configType,
-        readers: formValues.readers.map(({ value }) => value),
-        public: formValues.public,
-      }
-    } catch (error) {
-      throw new Error('There was a problem processing the form')
-    }
-  },
-  processConfigToFormFields: async (currentConfig, colors) => {
-    try {
-      const {
-        name,
-        type,
-        owner,
-        readers,
-        config,
-        public: publicConfig,
-      } = currentConfig
-      const configKey = Object.keys(config)[0]
-      const configCategoryFields = config[configKey].map(
-        ({ category, analysis, variable, label, range, color }) => {
-          const [min, max] = range
-          return {
-            analysis,
-            category,
-            variable,
-            label,
-            min,
-            max,
-            color: findCategoryColor(color, colors) || defaultColorValue,
-          }
+  processNewConfig: (formValues, colors, owner) => {
+    const config = {
+      0: formValues.config.map(({ min, max, color, ...rest }) => {
+        return {
+          color: colors.find(({ value }) => value === color).label,
+          range: [min, max],
+          ...rest,
         }
-      )
-      return {
-        configName: name,
-        configType: type,
-        owner: owner,
-        readers: readers.map((reader) => ({
-          value: reader,
-          label: reader,
-          isFixed: reader === owner,
-        })),
-        config: configCategoryFields,
-        public: publicConfig,
-      }
-    } catch (error) {
-      throw new Error('There was an error processing the configuration')
+      }),
+    }
+
+    return {
+      config,
+      name: formValues.configName,
+      owner,
+      type: formValues.configType,
+      readers: formValues.readers.map(({ value }) => value),
+      public: formValues.public,
     }
   },
-  message: {
-    successAdd: 'Config Added Successfully',
-    successUpdate: 'Config Updated Successfully ',
+  processConfigToFormFields: (currentConfig, colors) => {
+    const {
+      name,
+      type,
+      owner,
+      readers,
+      config,
+      public: publicConfig,
+    } = currentConfig
+    const configKey = Object.keys(config)[0]
+    const configCategoryFields = config[configKey].map(
+      ({ category, analysis, variable, label, range, color }) => {
+        const [min, max] = range
+
+        return {
+          analysis,
+          category,
+          variable,
+          label,
+          min,
+          max,
+          color: findCategoryColor(color, colors).value || defaultColorValue,
+        }
+      }
+    )
+    return {
+      configName: name,
+      configType: type,
+      owner: owner,
+      readers: readers.map((reader) => ({
+        value: reader,
+        label: reader,
+        isFixed: reader === owner,
+      })),
+      config: configCategoryFields,
+      public: publicConfig,
+    }
   },
 }
 
-export const findCategoryColor = (categoryColors, colors) => {
-  return colors.find(({ label }) =>
-    categoryColors.every((el, i) => el === label[i])
-  )
-}
+export const findCategoryColor = (categoryColors, colors) =>
+  colors.find(({ label }) => categoryColors.every((el, i) => el === label[i]))
+
 export default UserConfigModel

--- a/views/pages/DashboardPage/DashboardPage.test.jsx
+++ b/views/pages/DashboardPage/DashboardPage.test.jsx
@@ -9,7 +9,7 @@ import renderPage from '../../../test/PageRenderer'
 
 import DashboardPage from '.'
 
-const mockUser = createUser()
+const mockUser = createUser({ access: ['AA', 'BB', 'CC'] })
 const mockParticipants = createParticipantList()
 const mockedUsers = [
   mockUser,

--- a/views/pages/EditConfigPage.jsx
+++ b/views/pages/EditConfigPage.jsx
@@ -29,7 +29,7 @@ const EditConfigPage = () => {
 
   const handleFormData = async (formValues) => {
     try {
-      const updatedConfiguration = await UserConfigModel.processNewConfig(
+      const updatedConfiguration = UserConfigModel.processNewConfig(
         formValues,
         colors,
         uid
@@ -48,12 +48,8 @@ const EditConfigPage = () => {
   const fetchCurrentConfig = async () => {
     try {
       const data = await api.userConfigurations.findOne(uid, config_id)
-      const formValues = await UserConfigModel.processConfigToFormFields(
-        data,
-        colors
-      )
 
-      return formValues
+      return UserConfigModel.processConfigToFormFields(data, colors)
     } catch (error) {
       setNotification({
         open: true,

--- a/views/pages/NewConfigPage.jsx
+++ b/views/pages/NewConfigPage.jsx
@@ -29,7 +29,7 @@ const NewConfigPage = () => {
 
   const handleFormData = async (formValues) => {
     try {
-      const newConfigurationAttributes = await UserConfigModel.processNewConfig(
+      const newConfigurationAttributes = UserConfigModel.processNewConfig(
         formValues,
         colors,
         uid

--- a/views/pages/ParticipantsPage.jsx
+++ b/views/pages/ParticipantsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 
 import ParticipantsTable from '../tables/ParticipantsTable'
 import ParticipantsSearchForm from '../forms/ParticipantsSearchForm'
@@ -9,13 +9,14 @@ import useParticipantsList from '../hooks/useParticipantsList'
 const ParticipantsPage = () => {
   const {
     handleSearch,
-    searchSubjects,
+    formFilters,
+    loading,
     onSort,
     onStar,
-    sortBy,
-    sortDirection,
     participants,
     searchOptions,
+    sortBy,
+    sortDirection,
   } = useParticipantsList()
 
   return (
@@ -26,21 +27,27 @@ const ParticipantsPage = () => {
           <ParticipantsSearchForm
             onSubmit={handleSearch}
             initialValues={{
-              participants: searchSubjects,
+              participants: formFilters.searchSubjects,
+              status: formFilters.status,
+              studies: formFilters.studies,
             }}
             allOptions={searchOptions}
           />
         }
       />
 
-      <ParticipantsTable
-        participants={participants}
-        onStar={onStar}
-        onSort={onSort}
-        sortProperty={sortBy}
-        sortDirection={sortDirection}
-        sortable
-      />
+      {loading ? (
+        <Typography variant="h4">Loading...</Typography>
+      ) : (
+        <ParticipantsTable
+          participants={participants}
+          onStar={onStar}
+          onSort={onSort}
+          sortProperty={sortBy}
+          sortDirection={sortDirection}
+          sortable
+        />
+      )}
     </Box>
   )
 }

--- a/views/routes/routes.js
+++ b/views/routes/routes.js
@@ -77,10 +77,7 @@ export const apiRoutes = {
       `${apiPath}/dashboards/${study}/${subject}`,
   },
   participants: {
-    index: (queryParams) =>
-      queryParams
-        ? `${apiPath}/participants?${qs.stringify(queryParams)}`
-        : `${apiPath}/participants`,
+    index: `${apiPath}/participants`,
   },
   users: {
     index: `${apiPath}/users`,


### PR DESCRIPTION
closes #535 

This pr adds two additional methods to filter participants, by studies or by status. The mongo db query receives query params and builds a mongodb aggregate query for the selected options, refactored some small parts of the application, added watch subscription to control the amount of times we hit the api endpoint.

The studies dropdown has an additional search input to filter the dropdown list and it has two additional actions to select all and clear all.

The select component has been updated and the refactor led to some updates to the configurations page values handler. 

SelectProps has a MenuItem prop, the autofocus is set to true, this will automatically focus on the search input after an onchange event, without the autofocus true on menu Item, the on change event causes rerenders and input loses focus.

On smaller screens the filters are stacked vertically.

<img width="888" alt="Screenshot 2024-01-02 at 10 16 46 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/5970a815-589d-4021-b16b-836d017aac77">
<img width="1073" alt="Screenshot 2024-01-02 at 10 16 58 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/1edfe0dc-8a8c-4240-bbf6-da9d9eaa2a15">
<img width="581" alt="Screenshot 2024-01-02 at 10 17 53 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/0bd6f6f3-222c-4d75-b3d8-b20138746beb">
<img width="578" alt="Screenshot 2024-01-02 at 10 18 01 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/786342ae-6b06-49c1-84c0-322a0954ba5d">


