### PR TITLE
set SameSite: Strict policy for session cookie. As we are web-only this is all we need

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -35,6 +35,7 @@ const isProduction = process.env.NODE_ENV === 'production'
 const cookieAttributes = {
   secure: isProduction,
   maxAge: 24 * 60 * 60 * 1000,
+  sameSite: 'strict',
 }
 const app = express()
 


### PR DESCRIPTION
Reference: https://snyk.io/blog/how-to-protect-node-js-apps-from-csrf-attacks/

> When set to strict, the browser only sends session cookies in first-party contexts — it won't send them when a user navigates to a different website. This method effectively prevents CSRF attacks from malicious third-party sites.