### PR TITLE
Remove Help Link

### DIFF
--- a/views/components/Sidebar/SideNavigation.jsx
+++ b/views/components/Sidebar/SideNavigation.jsx
@@ -6,7 +6,6 @@ import {
   ShowChart,
   DashboardCustomize,
   AdminPanelSettings,
-  Flag,
 } from '@mui/icons-material'
 import NavItem from './NavItem'
 import { routes } from '../../routes/routes'
@@ -27,7 +26,6 @@ const SideNavigation = ({ user }) => {
           <NavItem Icon={AdminPanelSettings} to={routes.admin} label="Admin" />
         )}
         <Divider light />
-        <NavItem Icon={Flag} to={routes.help} label="Help" />
       </List>
     </nav>
   )

--- a/views/components/Sidebar/Sidebar.test.jsx
+++ b/views/components/Sidebar/Sidebar.test.jsx
@@ -28,12 +28,10 @@ describe('Sidebar', () => {
     const charts = screen.getByText('Charts')
     const participants = screen.getByText('Participants')
     const configurations = screen.getByText('Configurations')
-    const help = screen.getByText('Help')
 
     expect(dashboard).toBeInTheDocument()
     expect(charts).toBeInTheDocument()
     expect(participants).toBeInTheDocument()
     expect(configurations).toBeInTheDocument()
-    expect(help).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
We have a help link on the sidebar that links to a blank page. We are removing it for now.