### PR TITLE
make export as csv button visible

### DIFF
--- a/views/components/GraphTable/index.jsx
+++ b/views/components/GraphTable/index.jsx
@@ -21,7 +21,6 @@ const GraphTable = ({ graph, onGetCsv }) => {
       <Toolbar>
         <Button
           variant="outlined"
-          color="secondary"
           onClick={() => onGetCsv(graph.chart_id, graph.filters, graph.title)}
         >
           <ArrowDropDownIcon />


### PR DESCRIPTION
This pr adds more visibility to the export as csv button.

### After
<img width="1268" alt="Screenshot 2024-01-22 at 12 16 50 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/e6330fea-7d18-4a57-9113-929211f5b331">


### Before

![image](https://github.com/AMP-SCZ/dpdash/assets/19805355/373ec91a-2ea9-4818-ab38-fb9f218ca418)
