### PR TITLE
Fix metadata import

### DIFF
--- a/server/controllers/api/siteMetadataController/index.js
+++ b/server/controllers/api/siteMetadataController/index.js
@@ -1,4 +1,5 @@
 import SiteMetadataModel from '../../../models/SiteMetadataModel'
+import { collections } from '../../../utils/mongoCollections'
 
 const SiteMetadataController = {
   create: async (req, res) => {
@@ -48,6 +49,17 @@ const SiteMetadataController = {
       return res.status(200).json({ data: 'Metadata imported successfully.' })
     } catch (error) {
       return res.status(401).json({ message: error.message })
+    }
+  },
+  destroy: async (req, res) => {
+    try {
+      const { dataDb } = req.app.locals
+
+      await dataDb.collection(collections.metadata).drop()
+
+      return res.status(200).json({ data: 'Metadata collection restarted' })
+    } catch (error) {
+      return res.status(400).json({ message: error.message })
     }
   },
 }

--- a/server/controllers/api/siteMetadataController/siteMetadataController.test.js
+++ b/server/controllers/api/siteMetadataController/siteMetadataController.test.js
@@ -241,4 +241,49 @@ describe('siteMetadataController', () => {
       })
     })
   })
+  describe(SiteMetadataController.destroy, () => {
+    describe('When successful', () => {
+      let dataDb
+
+      beforeAll(() => {
+        dataDb = global.MONGO_INSTANCE.db('dpdata')
+      })
+      beforeEach(async () => {
+        await dataDb.createCollection('metadata')
+      })
+      afterAll(async () => {
+        await dataDb.dropDatabase()
+      })
+
+      it('removes the metadata collection', async () => {
+        const request = createRequest()
+        const response = createResponse()
+
+        await SiteMetadataController.destroy(request, response)
+
+        expect(response.status).toHaveBeenCalledWith(200)
+        expect(response.json).toHaveBeenCalledWith({
+          data: 'Metadata collection restarted',
+        })
+      })
+    })
+    describe('When unsuccessful', () => {
+      it('returns a status of 200 and an error', async () => {
+        const request = createRequest()
+        const response = createResponse()
+
+        request.app.locals.dataDb.collection.mockImplementation(() => {
+          return {
+            drop: jest.fn().mockRejectedValueOnce(new Error('some error')),
+          }
+        })
+        await SiteMetadataController.destroy(request, response)
+
+        expect(response.status).toHaveBeenCalledWith(400)
+        expect(response.json).toHaveBeenCalledWith({
+          message: 'some error',
+        })
+      })
+    })
+  })
 })

--- a/server/routes/siteMetadata.js
+++ b/server/routes/siteMetadata.js
@@ -8,5 +8,6 @@ const router = Router()
 router
   .route(v1Routes.siteMetadata.index)
   .post(ensureApiAuthenticated, SiteMetadataController.create)
+  .delete(ensureApiAuthenticated, SiteMetadataController.destroy)
 
 export default router

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -58,6 +58,7 @@ export const createDb = (overrides = {}) => ({
   }),
   distinct: jest.fn(),
   deleteOne: jest.fn(),
+  drop: jest.fn(),
   insertOne: jest.fn(),
   insertMany: jest.fn(),
   find: jest.fn(function () {


### PR DESCRIPTION
This pr fixes the data imported to display the days in study column on the UI. 
This adds the destroy method that drops the metadata collection and that allows for the data to be reimported.
