### PR TITLE
Document DB and Prod Networking Changes

### DIFF
--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -60,9 +60,9 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: dpdash
           IMAGE_TAG: ${{ github.sha }}
-          CLUSTER_NAME: dpDashDevCluster
-          TASK_NAME: dpDashDevTaskDefinition
-          SERVICE_NAME: dpDashDevService
+          CLUSTER_NAME: dpDashCluster
+          TASK_NAME: dpDashTaskDefinition
+          SERVICE_NAME: dpDashService
         run:
           | # Grab JSON of current DP Dash task definition, replace container image field with the new container and fix up the JSON, then upload the task and update the service with the new task
           export ECR_IMAGE="$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -60,9 +60,9 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: dpdash
           IMAGE_TAG: ${{ github.sha }}
-          CLUSTER_NAME: dpDashCluster
-          TASK_NAME: dpDashTaskDefinition
-          SERVICE_NAME: dpDashService
+          CLUSTER_NAME: dpDashDevCluster
+          TASK_NAME: dpDashDevTaskDefinition
+          SERVICE_NAME: dpDashDevService
         run:
           | # Grab JSON of current DP Dash task definition, replace container image field with the new container and fix up the JSON, then upload the task and update the service with the new task
           export ECR_IMAGE="$REGISTRY/$REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/deploy_infrastructure.yaml
+++ b/.github/workflows/deploy_infrastructure.yaml
@@ -29,4 +29,5 @@ jobs:
         BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
         APP_MEMORY: ${{ vars.APP_MEMORY || '2048' }}
         APP_CPU: ${{ vars.APP_CPU || '1024' }}
+        DPDASH_DEV: "1"
       run: npm run deploy -- --require-approval never

--- a/.github/workflows/deploy_infrastructure.yaml
+++ b/.github/workflows/deploy_infrastructure.yaml
@@ -29,5 +29,5 @@ jobs:
         BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
         APP_MEMORY: ${{ vars.APP_MEMORY || '2048' }}
         APP_CPU: ${{ vars.APP_CPU || '1024' }}
-        DPDASH_DEV: "1"
+        DPDASH_INFRA_STAGING: "1"
       run: npm run deploy -- --require-approval never

--- a/.github/workflows/deploy_infrastructure.yaml
+++ b/.github/workflows/deploy_infrastructure.yaml
@@ -19,7 +19,7 @@ jobs:
         role-to-assume: ${{ vars.ROLE_ARN }}
         aws-region: us-east-1
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      run: npm ci
     - name: Deploy Dev
       env:
         CDK_DEFAULT_ACCOUNT: ${{ vars.CDK_DEFAULT_ACCOUNT }}
@@ -27,8 +27,6 @@ jobs:
         EMAIL_SENDER: ${{ vars.EMAIL_SENDER }}
         ADMIN_EMAIL: ${{ vars.ADMIN_EMAIL }}
         BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
-        DEV_MONGO_MEMORY: ${{ vars.DEV_MONGO_MEMORY || '2048' }}
-        DEV_MONGO_CPU: ${{ vars.DEV_MONGO_CPU || '1024' }}
-        DEV_APP_MEMORY: ${{ vars.DEV_APP_MEMORY || '2048' }}
-        DEV_APP_CPU: ${{ vars.DEV_APP_CPU || '1024' }}
+        APP_MEMORY: ${{ vars.APP_MEMORY || '2048' }}
+        APP_CPU: ${{ vars.APP_CPU || '1024' }}
       run: npm run deploy -- --require-approval never

--- a/.github/workflows/display_infrastructure_template.yaml
+++ b/.github/workflows/display_infrastructure_template.yaml
@@ -29,4 +29,5 @@ jobs:
         BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
         APP_MEMORY: ${{ vars.APP_MEMORY || '2048' }}
         APP_CPU: ${{ vars.APP_CPU || '1024' }}
+        DPDASH_INFRA_STAGING: "1"
       run: npx cdk synth

--- a/.github/workflows/display_infrastructure_template.yaml
+++ b/.github/workflows/display_infrastructure_template.yaml
@@ -21,4 +21,12 @@ jobs:
     - name: Install dependencies
       run: npm ci --legacy-peer-deps
     - name: Synthesize Cloudformation
-      run: CDK_DEFAULT_ACCOUNT=${{ vars.CDK_DEFAULT_ACCOUNT }} CDK_DEFAULT_REGION=${{ vars.CDK_DEFAULT_REGION }} EMAIL_SENDER=${{ vars.EMAIL_SENDER }} ADMIN_EMAIL=${{ vars.ADMIN_EMAIL }} BASE_DOMAIN=${{ vars.BASE_DOMAIN }} npx cdk synth
+      env:
+        CDK_DEFAULT_ACCOUNT: ${{ vars.CDK_DEFAULT_ACCOUNT }}
+        CDK_DEFAULT_REGION: ${{ vars.CDK_DEFAULT_REGION }}
+        EMAIL_SENDER: ${{ vars.EMAIL_SENDER }}
+        ADMIN_EMAIL: ${{ vars.ADMIN_EMAIL }}
+        BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
+        APP_MEMORY: ${{ vars.APP_MEMORY || '2048' }}
+        APP_CPU: ${{ vars.APP_CPU || '1024' }}
+      run: npx cdk synth

--- a/bin/echo-secrets.sh
+++ b/bin/echo-secrets.sh
@@ -7,22 +7,14 @@ read -p "This script will log secret values to the console. Are you sure you wis
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
   aws ssm get-parameter \
-      --name "DPDASH_MONGODB_ADMIN_USER_DEV" \
+      --name "DPDASH_IMPORT_API_USERS" \
       --with-decryption
 
   aws ssm get-parameter \
-      --name "DPDASH_MONGODB_ADMIN_PASSWORD_DEV" \
+      --name "DPDASH_IMPORT_API_KEYS" \
       --with-decryption
 
   aws ssm get-parameter \
-      --name "DPDASH_IMPORT_API_USERS_DEV" \
-      --with-decryption
-
-  aws ssm get-parameter \
-      --name "DPDASH_IMPORT_API_KEYS_DEV" \
-      --with-decryption
-
-  aws ssm get-parameter \
-      --name "DPDASH_SESSION_SECRET_DEV" \
+      --name "DPDASH_SESSION_SECRET" \
       --with-decryption
 fi

--- a/bin/generate-secrets.sh
+++ b/bin/generate-secrets.sh
@@ -6,26 +6,14 @@
 # Set an environment variable as a comma separated list of usernames for the API users named DPDASH_IMPORT_API_USERS
 
 aws ssm put-parameter \
-    --name "DPDASH_MONGODB_ADMIN_USER_DEV" \
-    --value $DPDASH_MONGODB_ADMIN_USER_DEV \
+    --name "DPDASH_IMPORT_API_USERS" \
+    --value $DPDASH_IMPORT_API_USERS \
     --type SecureString \
     --tags "Key=Name,Value=dpdash"
 
+export DPDASH_NUMBER_OF_USERS=$(($(echo $DPDASH_IMPORT_API_USERS | tr -cd , | wc -c) + 1))
 aws ssm put-parameter \
-    --name "DPDASH_MONGODB_ADMIN_PASSWORD_DEV" \
-    --value $(openssl rand -base64 32 | tr -d "+=/") \
-    --type SecureString \
-    --tags "Key=Name,Value=dpdash"
-
-aws ssm put-parameter \
-    --name "DPDASH_IMPORT_API_USERS_DEV" \
-    --value $DPDASH_IMPORT_API_USERS_DEV \
-    --type SecureString \
-    --tags "Key=Name,Value=dpdash"
-
-export DPDASH_NUMBER_OF_USERS=$(($(echo $DPDASH_IMPORT_API_USERS_DEV | tr -cd , | wc -c) + 1))
-aws ssm put-parameter \
-    --name "DPDASH_IMPORT_API_KEYS_DEV" \
+    --name "DPDASH_IMPORT_API_KEYS" \
     --value $(
       for i in seq $DPDASH_NUMBER_OF_USERS; do
         echo $(openssl rand -base64 32 | tr -d "+=/")
@@ -35,7 +23,7 @@ aws ssm put-parameter \
     --tags "Key=Name,Value=dpdash"
 
 aws ssm put-parameter \
-    --name "DPDASH_SESSION_SECRET_DEV" \
+    --name "DPDASH_SESSION_SECRET" \
     --value $(openssl rand -base64 32 | tr -d "+=/") \
     --type SecureString \
     --tags "Key=Name,Value=dpdash"

--- a/cdk_lib/dpdash-cdk-stack.test.ts
+++ b/cdk_lib/dpdash-cdk-stack.test.ts
@@ -1,0 +1,42 @@
+import { Capture, Match, Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
+import { DpdashCdkStack } from './dpdash-cdk-stack';
+
+describe('DPDashCDKStack', () => {
+  const OLD_ENV = process.env
+  const setEnv = (overrides = {}) => {
+    process.env = {
+      CDK_DEFAULT_ACCOUNT: '000000000000',
+      CDK_DEFAULT_REGION: 'us-east-1',
+      EMAIL_SENDER: 'noreply@dpdash.example.com',
+      ADMIN_EMAIL: 'alice@example.com',
+      BASE_DOMAIN: 'dpdash.example.com',
+      APP_MEMORY: '2048',
+      APP_CPU: '1024',
+      ...overrides
+    }
+  }
+
+  const createTemplate = () => {
+    const app = new cdk.App()
+    const dpDashCdkStack = new DpdashCdkStack(app, "DPDashCDKStack")
+    return Template.fromStack(dpDashCdkStack)
+  }
+
+  beforeEach(() => {
+    jest.resetModules() // Most important - it clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  it('creates a DocumentDB Cluster', async () => {
+    setEnv()
+    const template = createTemplate()
+
+    template.hasResource('AWS::DocDB::DBCluster', {})
+    template.hasResource('AWS::DocDB::DBInstance', {})
+  })
+})

--- a/cdk_lib/dpdash-cdk-stack.test.ts
+++ b/cdk_lib/dpdash-cdk-stack.test.ts
@@ -13,6 +13,7 @@ describe('DPDashCDKStack', () => {
       BASE_DOMAIN: 'dpdash.example.com',
       APP_MEMORY: '2048',
       APP_CPU: '1024',
+      DPDASH_DEV: '1',
       ...overrides
     }
   }
@@ -24,19 +25,28 @@ describe('DPDashCDKStack', () => {
   }
 
   beforeEach(() => {
-    jest.resetModules() // Most important - it clears the cache
-    process.env = { ...OLD_ENV }; // Make a copy
+    jest.resetModules()
+    process.env = { ...OLD_ENV };
   });
 
   afterAll(() => {
-    process.env = OLD_ENV; // Restore old environment
+    process.env = OLD_ENV;
   });
 
-  it('creates a DocumentDB Cluster', async () => {
+  it('creates a DocumentDB Cluster', () => {
     setEnv()
     const template = createTemplate()
 
     template.hasResource('AWS::DocDB::DBCluster', {})
     template.hasResource('AWS::DocDB::DBInstance', {})
+  })
+
+  it('creates an Application Load Balanced Fargate Service', () => {
+    setEnv()
+    const template = createTemplate()
+
+    template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {})
+    template.hasResource('AWS::ECS::Cluster', {})
+    template.hasResource('AWS::ECS::Service', {})
   })
 })

--- a/cdk_lib/dpdash-cdk-stack.test.ts
+++ b/cdk_lib/dpdash-cdk-stack.test.ts
@@ -53,8 +53,21 @@ describe('DPDashCDKStack', () => {
     const template = createTemplate()
 
     template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {})
-    template.hasResource('AWS::ECS::Cluster', {})
-    template.hasResource('AWS::ECS::Service', {})
+    template.hasResource('AWS::ECS::Cluster', {
+      'Properties': {
+        'ClusterName': 'dpDashDevCluster'
+      }
+    })
+    template.hasResource('AWS::ECS::Service', {
+      'Properties': {
+        'ServiceName': 'dpDashDevService'
+      }
+    })
+    template.hasResource('AWS::ECS::TaskDefinition', {
+      'Properties': {
+        'Family': 'dpDashDevTaskDefinition'
+      }
+    })
   })
 
   describe('when the DPDASH_DEV flag is set to "1"', () => {
@@ -98,8 +111,23 @@ describe('DPDashCDKStack', () => {
       const template = createTemplate()
 
       template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+          'Properties': {
+            'Scheme': 'internal'
+          }
+        })
+        template.hasResource('AWS::ECS::Cluster', {
         'Properties': {
-          'Scheme': 'internal'
+          'ClusterName': 'dpDashCluster'
+        }
+      })
+      template.hasResource('AWS::ECS::Service', {
+        'Properties': {
+          'ServiceName': 'dpDashService'
+        }
+      })
+      template.hasResource('AWS::ECS::TaskDefinition', {
+        'Properties': {
+          'Family': 'dpDashTaskDefinition'
         }
       })
     })

--- a/cdk_lib/dpdash-cdk-stack.test.ts
+++ b/cdk_lib/dpdash-cdk-stack.test.ts
@@ -12,7 +12,7 @@ describe('DPDashCDKStack', () => {
       BASE_DOMAIN: 'dpdash.example.com',
       APP_MEMORY: '2048',
       APP_CPU: '1024',
-      DPDASH_DEV: '1',
+      DPDASH_INFRA_STAGING: '1',
       ...overrides
     }
   }
@@ -63,7 +63,7 @@ describe('DPDashCDKStack', () => {
     })
   })
 
-  describe('when the DPDASH_DEV flag is set to "1"', () => {
+  describe('when the DPDASH_INFRA_STAGING flag is set to "1"', () => {
     it('creates a Hosted Zone', () => {
       setEnv()
       const template = createTemplate(DpdashCdkStack)
@@ -93,9 +93,9 @@ describe('DPDashCDKStack', () => {
       })
     })
   })
-  describe('when the DPDASH_DEV flag is not set to "1"', () => {
+  describe('when the DPDASH_INFRA_STAGING flag is not set to "1"', () => {
     it('throws an error if the CERT_ARN and SES_IDENTITY_ARN are missing', () => {
-      setEnv({ DPDASH_DEV: undefined })
+      setEnv({ DPDASH_INFRA_STAGING: undefined })
       expect(() => createTemplate(DpdashCdkStack)).toThrowError("Missing required environment variables: CERT_ARN, SES_IDENTITY_ARN")
     })
 

--- a/cdk_lib/dpdash-cdk-stack.test.ts
+++ b/cdk_lib/dpdash-cdk-stack.test.ts
@@ -100,7 +100,7 @@ describe('DPDashCDKStack', () => {
     })
 
     it('creates a private Application Load Balanced Fargate Service', () => {
-      setEnv({ DPDASH_DEV: undefined, CERT_ARN: 'foo', SES_IDENTITY_ARN: 'bar' })
+      setEnv({ DPDASH_INFRA_STAGING: undefined, CERT_ARN: 'foo', SES_IDENTITY_ARN: 'bar' })
       const template = createTemplate(DpdashCdkStack)
 
       template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {

--- a/cdk_lib/dpdash-cdk-stack.test.ts
+++ b/cdk_lib/dpdash-cdk-stack.test.ts
@@ -1,6 +1,5 @@
-import { Capture, Match, Template } from 'aws-cdk-lib/assertions';
-import * as cdk from 'aws-cdk-lib';
-import { DpdashCdkStack } from './dpdash-cdk-stack';
+import { createTemplate } from './test/fixtures'
+import { DpdashCdkStack } from './dpdash-cdk-stack'
 
 describe('DPDashCDKStack', () => {
   const OLD_ENV = process.env
@@ -18,12 +17,6 @@ describe('DPDashCDKStack', () => {
     }
   }
 
-  const createTemplate = () => {
-    const app = new cdk.App()
-    const dpDashCdkStack = new DpdashCdkStack(app, "DPDashCDKStack")
-    return Template.fromStack(dpDashCdkStack)
-  }
-
   beforeEach(() => {
     jest.resetModules()
     process.env = { ...OLD_ENV };
@@ -35,14 +28,14 @@ describe('DPDashCDKStack', () => {
 
   it('creates a VPC', () => {
     setEnv()
-    const template = createTemplate()
+    const template = createTemplate(DpdashCdkStack)
 
     template.hasResource('AWS::EC2::VPC', {})
   })
 
   it('creates a DocumentDB Cluster', () => {
     setEnv()
-    const template = createTemplate()
+    const template = createTemplate(DpdashCdkStack)
 
     template.hasResource('AWS::DocDB::DBCluster', {})
     template.hasResource('AWS::DocDB::DBInstance', {})
@@ -50,7 +43,7 @@ describe('DPDashCDKStack', () => {
 
   it('creates an Application Load Balanced Fargate Service', () => {
     setEnv()
-    const template = createTemplate()
+    const template = createTemplate(DpdashCdkStack)
 
     template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {})
     template.hasResource('AWS::ECS::Cluster', {
@@ -73,25 +66,25 @@ describe('DPDashCDKStack', () => {
   describe('when the DPDASH_DEV flag is set to "1"', () => {
     it('creates a Hosted Zone', () => {
       setEnv()
-      const template = createTemplate()
+      const template = createTemplate(DpdashCdkStack)
       template.hasResource('AWS::Route53::HostedZone', {})
     })
 
     it('creates a Certificate', () => {
       setEnv()
-      const template = createTemplate()
+      const template = createTemplate(DpdashCdkStack)
       template.hasResource('AWS::CertificateManager::Certificate', {})
     })
 
     it('creates an SES Email Identity', () => {
       setEnv()
-      const template = createTemplate()
+      const template = createTemplate(DpdashCdkStack)
       template.hasResource('AWS::SES::EmailIdentity', {})
     })
 
     it('creates a public Application Load Balanced Fargate Service', () => {
       setEnv()
-      const template = createTemplate()
+      const template = createTemplate(DpdashCdkStack)
 
       template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
         'Properties': {
@@ -103,12 +96,12 @@ describe('DPDashCDKStack', () => {
   describe('when the DPDASH_DEV flag is not set to "1"', () => {
     it('throws an error if the CERT_ARN and SES_IDENTITY_ARN are missing', () => {
       setEnv({ DPDASH_DEV: undefined })
-      expect(createTemplate).toThrowError("Missing required environment variables: CERT_ARN, SES_IDENTITY_ARN")
+      expect(() => createTemplate(DpdashCdkStack)).toThrowError("Missing required environment variables: CERT_ARN, SES_IDENTITY_ARN")
     })
 
     it('creates a private Application Load Balanced Fargate Service', () => {
       setEnv({ DPDASH_DEV: undefined, CERT_ARN: 'foo', SES_IDENTITY_ARN: 'bar' })
-      const template = createTemplate()
+      const template = createTemplate(DpdashCdkStack)
 
       template.hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
           'Properties': {

--- a/cdk_lib/dpdash-cdk-stack.ts
+++ b/cdk_lib/dpdash-cdk-stack.ts
@@ -60,15 +60,15 @@ export class DpdashCdkStack extends cdk.Stack {
 
     const secrets = {
       sessionSecretDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}SessionDevSecret`, {
-        parameterName: 'DPDASH_SESSION_SECRET',
+        parameterName: 'DPDASH_SESSION_SECRET' + IS_DEV ? '_DEV' : '',
         version: 1,
       })),
       importApiUsersDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}ImportApiUsers`, {
-        parameterName: 'DPDASH_IMPORT_API_USERS',
+        parameterName: 'DPDASH_IMPORT_API_USERS' + IS_DEV ? '_DEV' : '',
         version: 1,
       })),
       importApiKeysDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}ImportApiKeysDev`, {
-        parameterName: 'DPDASH_IMPORT_API_KEYS',
+        parameterName: 'DPDASH_IMPORT_API_KEYS' + IS_DEV ? '_DEV' : '',
         version: 1,
       })),
     }
@@ -102,7 +102,7 @@ export class DpdashCdkStack extends cdk.Stack {
     const appTaskDefinition = new ecs.FargateTaskDefinition(this, `${APP_NAME}AppTaskDefinition`, {
       memoryLimitMiB: process.env.DEV_APP_MEMORY ? Number(process.env.DEV_APP_MEMORY) : 2048,
       cpu:  process.env.DEV_APP_CPU ? Number(process.env.DEV_APP_CPU) : 1024,
-      family: 'dpDashTaskDefinition',
+      family: IS_DEV ? 'dpDashDevTaskDefinition' : 'dpDashTaskDefinition',
       taskRole: new iam.Role(this, `${APP_NAME}AppTaskRole`, {
         assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
         inlinePolicies: {
@@ -138,11 +138,11 @@ export class DpdashCdkStack extends cdk.Stack {
     });
 
     const dpDashService = new ecs_patterns.ApplicationLoadBalancedFargateService(this, `${APP_NAME}AppService`, {
-      serviceName: 'dpDashService',
-      loadBalancerName: 'dpDashLoadBalancer',
+      serviceName: IS_DEV ? 'dpDashDevService' : 'dpDashService',
+      loadBalancerName: IS_DEV ? 'dpDashDevService' : 'dpDashLoadBalancer',
       cluster: new ecs.Cluster(this, `${APP_NAME}Cluster`, {
         vpc,
-        clusterName: 'dpDashCluster',
+        clusterName: IS_DEV ? 'dpDashDevCluster' : 'dpDashCluster',
       }),
       taskDefinition: appTaskDefinition,
       assignPublicIp: true,

--- a/cdk_lib/dpdash-cdk-stack.ts
+++ b/cdk_lib/dpdash-cdk-stack.ts
@@ -12,8 +12,6 @@ import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
 import * as secrets_manager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from 'constructs';
 
-const IS_DEV = process.env.DPDASH_DEV === "1"
-const APP_NAME =  IS_DEV ? "DpDashDev" : "DPDash";
 
 export class DpdashCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -24,6 +22,9 @@ export class DpdashCdkStack extends cdk.Stack {
       },
       ...props,
     });
+    const IS_DEV = process.env.DPDASH_DEV === "1"
+    const APP_NAME =  IS_DEV ? "DpDashDev" : "DPDash";
+
     let certArn
     let sesIdentityArn
     let cert

--- a/cdk_lib/dpdash-cdk-stack.ts
+++ b/cdk_lib/dpdash-cdk-stack.ts
@@ -1,18 +1,18 @@
 import * as cdk from 'aws-cdk-lib';
-import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";
-import * as efs from "aws-cdk-lib/aws-efs";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as ses from "aws-cdk-lib/aws-ses";
 import * as ecr from "aws-cdk-lib/aws-ecr";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as docdb from "aws-cdk-lib/aws-docdb";
 import * as route53 from "aws-cdk-lib/aws-route53";
 import * as certificate_manager from "aws-cdk-lib/aws-certificatemanager";
 import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
+import * as secrets_manager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from 'constructs';
 
-const APP_NAME = "DpDash";
+const APP_NAME = process.env.DEV === "1" ? "DpDashDev" : "DPDash";
 
 export class DpdashCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -23,57 +23,45 @@ export class DpdashCdkStack extends cdk.Stack {
       },
       ...props,
     });
-    let devCertArn
+    let certArn
     let sesIdentityArn
-    let devCert
+    let cert
 
     if (!process.env.BASE_DOMAIN || !process.env.ADMIN_EMAIL || !process.env.EMAIL_SENDER) {
       throw new Error('Missing required environment variables: BASE_DOMAIN, ADMIN_EMAIL, EMAIL_SENDER');
     }
 
     if (process.env.DEV_CERT_ARN) {
-      devCertArn = process.env.DEV_CERT_ARN;
+      certArn = process.env.DEV_CERT_ARN;
       sesIdentityArn = `arn:aws:ses:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identity/${process.env.BASE_DOMAIN}`
     } else {
       const hostedZone = new route53.PublicHostedZone(this, `${APP_NAME}HostedZone`, {
         zoneName: process.env.BASE_DOMAIN
       });
 
-      const devHostedZone = new route53.PublicHostedZone(this, `${APP_NAME}DevHostedZone`, {
-        zoneName: `staging.${process.env.BASE_DOMAIN}`,
-      });
-
-      devCert = new certificate_manager.Certificate(this, `${APP_NAME}DevCertificate`, {
-        domainName: `staging.${process.env.BASE_DOMAIN}`,
-        validation: certificate_manager.CertificateValidation.fromDns(devHostedZone),
+      cert = new certificate_manager.Certificate(this, `${APP_NAME}DevCertificate`, {
+        domainName: `${process.env.BASE_DOMAIN}`,
+        validation: certificate_manager.CertificateValidation.fromDns(hostedZone),
       });
 
       const identity = new ses.EmailIdentity(this, 'Identity', {
         identity: ses.Identity.publicHostedZone(hostedZone),
       });
 
-      devCertArn = devCert.certificateArn;
+      certArn = cert.certificateArn;
       sesIdentityArn = `arn:aws:ses:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:identity/${process.env.BASE_DOMAIN}`
     }
     const secrets = {
-      mongoDbUserDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}MongoDbUser`, {
-        parameterName: 'DPDASH_MONGODB_ADMIN_USER_DEV',
-        version: 1,
-      })),
-      mongoDbPasswordDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}MongoDbPassword`, {
-        parameterName: 'DPDASH_MONGODB_ADMIN_PASSWORD_DEV',
-        version: 1,
-      })),
       sessionSecretDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}SessionDevSecret`, {
-        parameterName: 'DPDASH_SESSION_SECRET_DEV',
+        parameterName: 'DPDASH_SESSION_SECRET',
         version: 1,
       })),
       importApiUsersDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}ImportApiUsers`, {
-        parameterName: 'DPDASH_IMPORT_API_USERS_DEV',
+        parameterName: 'DPDASH_IMPORT_API_USERS',
         version: 1,
       })),
       importApiKeysDev: ecs.Secret.fromSsmParameter(ssm.StringParameter.fromSecureStringParameterAttributes(this, `${APP_NAME}ImportApiKeysDev`, {
-        parameterName: 'DPDASH_IMPORT_API_KEYS_DEV',
+        parameterName: 'DPDASH_IMPORT_API_KEYS',
         version: 1,
       })),
     }
@@ -81,138 +69,34 @@ export class DpdashCdkStack extends cdk.Stack {
       availabilityZones: [`${cdk.Aws.REGION}a`, `${cdk.Aws.REGION}b`],
     });
 
-    const efsSecurityGroup = new ec2.SecurityGroup(this,`${APP_NAME}DevEfsSg`, {
-      vpc,
-    });
+    const ddbPassSecret = new secrets_manager.Secret(this,'DocumentDB Password',{
+      secretName:'DPDASH_MONGODB_ADMIN_PASSWORD',
+      generateSecretString:{
+        excludePunctuation:true,
+        excludeCharacters:"/¥'%:;{}"
+      }
+    })
 
-    const mongoRepository = ecr.Repository.fromRepositoryName(this, `${APP_NAME}DevMongoRepository`, "mongo");
-    const dpdashRepository = ecr.Repository.fromRepositoryName(this, `${APP_NAME}DevDpdashRepository`, "dpdash");
-
-    const mongoTaskDefinition = new ecs.FargateTaskDefinition(this, `${APP_NAME}DevMongoTaskDefinition`, {
-      memoryLimitMiB: process.env.DEV_MONGO_MEMORY ? Number(process.env.DEV_MONGO_MEMORY) : 2048,
-      cpu:  process.env.DEV_MONGO_CPU ? Number(process.env.DEV_MONGO_CPU) : 1024,
-    });
-
-    const fileSystem = new efs.FileSystem(this, `${APP_NAME}DevEfsFileSystem`, {
-      vpc,
-      securityGroup: efsSecurityGroup,
-      encrypted: true,
+    const mongoCluster = new docdb.DatabaseCluster(this, `${APP_NAME}DatabaseDbCluster`, {
+      vpc: vpc,
+      masterUser: {
+        username: 'dpdash',
+        password: ddbPassSecret.secretValue
+      },
+      instances: 1,
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE),
       vpcSubnets: {
-        subnets: vpc.privateSubnets,
-      },
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-     });
+        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS
+      }
+    })
 
-    const accessPoint = new efs.AccessPoint(this, `${APP_NAME}DevVolumeAccessPoint`,  {
-      fileSystem: fileSystem,
-   })
+    const dpdashRepository = ecr.Repository.fromRepositoryName(this, `${APP_NAME}DpdashRepository`, "dpdash");
 
-    mongoTaskDefinition.addVolume({
-      name: "mongo-data",
-      efsVolumeConfiguration: {
-        fileSystemId: fileSystem.fileSystemId,
-        authorizationConfig: {
-          accessPointId: accessPoint.accessPointId,
-          iam: "ENABLED",
-        },
-        transitEncryption: "ENABLED",
-      },
-    });
-
-    mongoTaskDefinition.addToTaskRolePolicy(
-      new iam.PolicyStatement({
-        actions: [
-          'elasticfilesystem:ClientRootAccess',
-          'elasticfilesystem:ClientWrite',
-          'elasticfilesystem:ClientMount',
-          'elasticfilesystem:DescribeMountTargets',
-        ],
-        resources: [
-          fileSystem.fileSystemArn,
-        ],
-      })
-    );
-
-    mongoTaskDefinition.addToTaskRolePolicy(
-      new iam.PolicyStatement({
-        actions: ['ec2:DescribeAvailabilityZones'],
-        resources: ['*'],
-      })
-    );
-
-    const mongoContainer = mongoTaskDefinition.addContainer(`${APP_NAME}DevMongoContainer`, {
-      image: ecs.ContainerImage.fromEcrRepository(mongoRepository, "5.0.21"),
-      portMappings: [{ containerPort: 27017 }],
-      logging: ecs.LogDrivers.awsLogs({ streamPrefix: `${APP_NAME}DevMongoContainer` }),
-      secrets: {
-        MONGO_INITDB_ROOT_USERNAME: secrets.mongoDbUserDev,
-        MONGO_INITDB_ROOT_PASSWORD: secrets.mongoDbPasswordDev,
-      },
-    });
-
-    mongoContainer.addMountPoints({
-      containerPath: "/data/db",
-      readOnly: false,
-      sourceVolume: "mongo-data",
-    });
-
-    const mongoDevFargateService = new ecs.FargateService(this, `${APP_NAME}DevMongoFargateService`, {
-      cluster: new ecs.Cluster(this, `${APP_NAME}DevMongoCluster`, {
-        vpc,
-        clusterName: 'dpDashDevMongoCluster',
-      }),
-      taskDefinition: mongoTaskDefinition,
-      desiredCount: 1,
-      assignPublicIp: false,
-    });
-
-    const mongoNetworkLoadBalancer = new elbv2.NetworkLoadBalancer(this, `${APP_NAME}DevMongoNetworkLoadBalancer`, {
-      vpc,
-      vpcSubnets: {
-        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-      },
-      internetFacing: false,
-    });
-
-    const mongoNlbListener = mongoNetworkLoadBalancer.addListener(`${APP_NAME}DevMongoListener`, {
-      port: 27017,
-      protocol: elbv2.Protocol.TCP,
-    });
-
-    const mongoDevServiceTarget = mongoDevFargateService.loadBalancerTarget({
-      containerName: `${APP_NAME}DevMongoContainer`,
-      containerPort: 27017,
-    });
-
-    mongoNlbListener.addTargets(`${APP_NAME}DevMongoListenerTarget`, {
-      port: 27017,
-      protocol: elbv2.Protocol.TCP,
-      targets: [mongoDevServiceTarget],
-    });
-
-
-    const mongoDevServiceLbSg = new ec2.SecurityGroup(this, "NLBSecurityGroup", { vpc });
-
-    const cfnlb = mongoNetworkLoadBalancer.node.defaultChild as elbv2.CfnLoadBalancer;
-
-    cfnlb.addPropertyOverride("SecurityGroups", [mongoDevServiceLbSg.securityGroupId]);
-
-    efsSecurityGroup.addIngressRule(
-        mongoDevFargateService.connections.securityGroups[0],
-        ec2.Port.tcp(2049) // Enable NFS service within security group
-    )
-
-    mongoDevFargateService.connections.allowFrom(
-      mongoDevServiceLbSg,
-      ec2.Port.tcp(27017),
-      "Allow inbound access from MongoDb NLB"
-    )
-
-    const appTaskDefinition = new ecs.FargateTaskDefinition(this, `${APP_NAME}DevAppTaskDefinition`, {
+    const appTaskDefinition = new ecs.FargateTaskDefinition(this, `${APP_NAME}AppTaskDefinition`, {
       memoryLimitMiB: process.env.DEV_APP_MEMORY ? Number(process.env.DEV_APP_MEMORY) : 2048,
       cpu:  process.env.DEV_APP_CPU ? Number(process.env.DEV_APP_CPU) : 1024,
-      family: 'dpDashDevTaskDefinition',
-      taskRole: new iam.Role(this, `${APP_NAME}DevAppTaskRole`, {
+      family: 'dpDashTaskDefinition',
+      taskRole: new iam.Role(this, `${APP_NAME}AppTaskRole`, {
         assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
         inlinePolicies: {
           sendEmail: new iam.PolicyDocument({
@@ -227,46 +111,43 @@ export class DpdashCdkStack extends cdk.Stack {
       })
     })
 
-    appTaskDefinition.addContainer(`${APP_NAME}DevAppContainer`, {
+    appTaskDefinition.addContainer(`${APP_NAME}AppContainer`, {
       image: ecs.ContainerImage.fromEcrRepository(dpdashRepository, "latest"),
       portMappings: [{ containerPort: 8000}],
       environment: {
-        MONGODB_HOST: mongoNetworkLoadBalancer.loadBalancerDnsName,
+        MONGODB_HOST: mongoCluster.clusterEndpoint.hostname,
+        MONGODB_USER: 'dpdash',
         ADMIN_EMAIL: process.env.ADMIN_EMAIL,
         EMAIL_SENDER: process.env.EMAIL_SENDER,
         HOME_URL: `https://staging.${process.env.BASE_DOMAIN}/admin`,
       },
       secrets: {
-        MONGODB_USER: secrets.mongoDbUserDev,
-        MONGODB_PASSWORD: secrets.mongoDbPasswordDev,
+        MONGODB_PASSWORD: ecs.Secret.fromSecretsManager(ddbPassSecret, "password"),
         SESSION_SECRET: secrets.sessionSecretDev,
         IMPORT_API_USERS: secrets.importApiUsersDev,
         IMPORT_API_KEYS: secrets.importApiKeysDev,
       },
-      logging: ecs.LogDrivers.awsLogs({ streamPrefix: `${APP_NAME}DevAppContainer` }),
+      logging: ecs.LogDrivers.awsLogs({ streamPrefix: `${APP_NAME}AppContainer` }),
     });
 
-    const dpDashDevService = new ecs_patterns.ApplicationLoadBalancedFargateService(this, `${APP_NAME}DevAppService`, {
-      serviceName: 'dpDashDevService',
-      loadBalancerName: 'dpDashDevLoadBalancer',
-      cluster: new ecs.Cluster(this, `${APP_NAME}DevCluster`, {
+    const dpDashService = new ecs_patterns.ApplicationLoadBalancedFargateService(this, `${APP_NAME}AppService`, {
+      serviceName: 'dpDashService',
+      loadBalancerName: 'dpDashLoadBalancer',
+      cluster: new ecs.Cluster(this, `${APP_NAME}Cluster`, {
         vpc,
-        clusterName: 'dpDashDevCluster',
+        clusterName: 'dpDashCluster',
       }),
       taskDefinition: appTaskDefinition,
       assignPublicIp: true,
-      publicLoadBalancer: true,
+      publicLoadBalancer: false,
       redirectHTTP: true,
-      certificate: devCert || certificate_manager.Certificate.fromCertificateArn(this, `${APP_NAME}DevCertificate`, devCertArn),
+      certificate: cert || certificate_manager.Certificate.fromCertificateArn(this, `${APP_NAME}Certificate`, certArn),
       taskSubnets: {
-        subnets: vpc.publicSubnets.concat(vpc.privateSubnets),
+        subnets: vpc.privateSubnets
       },
     });
 
-    mongoDevServiceLbSg.addIngressRule(
-      dpDashDevService.service.connections.securityGroups[0],
-      ec2.Port.tcp(27017),
-      "Allow inbound access to MongoDb"
-    )
+    
+    mongoCluster.connections.allowFrom(dpDashService.cluster.connections, ec2.Port.tcp(27017))
   }
 }

--- a/cdk_lib/dpdash-cdk-stack.ts
+++ b/cdk_lib/dpdash-cdk-stack.ts
@@ -22,7 +22,7 @@ export class DpdashCdkStack extends cdk.Stack {
       },
       ...props,
     });
-    const IS_DEV = process.env.DPDASH_DEV === "1"
+    const IS_DEV = process.env.DPDASH_INFRA_STAGING === "1"
     const APP_NAME =  IS_DEV ? "DpDashDev" : "DPDash";
 
     let certArn

--- a/cdk_lib/test/fixtures.ts
+++ b/cdk_lib/test/fixtures.ts
@@ -6,6 +6,6 @@ type StackConstructor<T extends cdk.Stack> = new (construct: Construct, id: stri
 
 export const createTemplate = <T extends cdk.Stack>(stackConstructor: StackConstructor<T>) => {
   const app = new cdk.App()
-  const stack = new stackConstructor(app, "DPDashCDKStack")
+  const stack = new stackConstructor(app, "StackUnderTest")
   return Template.fromStack(stack)
 }

--- a/cdk_lib/test/fixtures.ts
+++ b/cdk_lib/test/fixtures.ts
@@ -1,0 +1,11 @@
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+type StackConstructor<T extends cdk.Stack> = new (construct: Construct, id: string) => T
+
+export const createTemplate = <T extends cdk.Stack>(stackConstructor: StackConstructor<T>) => {
+  const app = new cdk.App()
+  const stack = new stackConstructor(app, "DPDashCDKStack")
+  return Template.fromStack(stack)
+}

--- a/jestCdkConfig.js
+++ b/jestCdkConfig.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: "ts-jest"
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "concurrently \"npm run test:ui\" \"npm run test:server\"",
     "test:ui": "jest --env=jsdom --config=jestUIConfig.js views/",
     "test:server": "jest --config=jestServerConfig.js server/",
+    "test:cdk": "jest --config=jestCdkConfig.js cdk_lib/",
     "bootstrap": "cdk bootstrap",
     "deploy": "cdk deploy"
   },


### PR DESCRIPTION
For the current environment in Justin's account, we'll need to change the following Github Variables:

BASE_DOMAIN should equal `staging.dpdash.itpmclean.org` rather than `dpdash.itpmclean.org`
~DPDASH_DEV should be created and set to 1.~ (Edit: I've hardcoded this in the yaml for now)
MONGO_ADMIN_PASSWORD_DEV and MONGO_ADMIN_USER_DEV can be deleted.

This PR is serving two purposes. One is to migrate to Document DB, per #619 . The other is to make the Application Load Balancer internal only (i.e. not internet-facing) and gate the differences between our current staging environment and the eventual prod architecture behind an IS_DEV flag, per #627 .

I combined these two issues because the production architecture will definitely use Document DB and I want the MGB architecture team to have an accurate picture of that architecture so they can review the code.

To mitigate the risk associated with combining the two changes, I've also added a basic test file for the logic, to ensure only the relevant Document DB changes will be deployed in the staging environment.