### PR TITLE
Matrix Page Crashes when there is no data

### DIFF
--- a/views/components/Matrix.d3.js
+++ b/views/components/Matrix.d3.js
@@ -197,7 +197,7 @@ export default class Matrix {
 
     this.svg.attr(
       'transform',
-      `translate(${this.maxYAxisWidth + margin.left},${margin.top})`
+      `translate(${this.maxYAxisWidth + margin.left},${margin.top - 5})`
     )
     leftMarginWhiteOut.attr(
       'transform',
@@ -212,7 +212,6 @@ export default class Matrix {
     this.generateMarginWhiteOutTop()
     this.xAxisForDatesData = this.generateXAxisForDatesData()
     this.generateXAxis()
-    this.generatePlotDataButton()
     this.generateWhiteSpaceTopLeft()
 
     if (this.startFromTheLastDay) {
@@ -426,15 +425,17 @@ export default class Matrix {
 
     this.xScaleLinearTop = d3
       .scaleLinear()
-      .range([cellWidth / 2, xAxisRange[xAxisRange.length - 1]])
+      .range([cellWidth / 2, xAxisRange[xAxisRange.length - 1] || 0])
       .domain([0, xAxisForDatesData.length - 1])
     this.xScaleLinearBottom = d3
       .scaleLinear()
-      .range([cellWidth / 2, xAxisRange[xAxisRange.length - 1]])
-      .domain([startDay, xAxisForDatesData[xAxisForDatesData.length - 1].day])
+      .range([cellWidth / 2, xAxisRange[xAxisRange.length - 1] || 0])
+      .domain(
+        [startDay, xAxisForDatesData[xAxisForDatesData.length - 1]?.day] || 0
+      )
     this.xAxisLinearTop = d3
       .axisTop(this.xScaleLinearTop)
-      .ticks(xAxisForDatesData.length - 1)
+      .ticks(xAxisForDatesData.length - 1 || 1)
       .tickValues(xAxisValuesTop)
 
     if (xAxisForDatesData.length > 0) {
@@ -443,11 +444,10 @@ export default class Matrix {
         .ticks(xAxisForDatesData.length - 1)
         .tickValues(xAxisValuesBottom)
         .tickFormat(d3.format('d'))
-
       this.xAxisBottom = this.svg
         .append('g')
         .attr('class', 'xAxisLinearBottom')
-        .attr('transform', () => `translate(0,${xAxisBottomYCoordinate})`)
+        .attr('transform', () => `translate(0,${xAxisBottomYCoordinate - 8})`)
         .call(this.xAxisLinearBottom)
       this.xAxisBottom
         .selectAll('text')
@@ -470,50 +470,6 @@ export default class Matrix {
 
     this.xAxisTop.selectAll('path').attr('stroke-opacity', 0)
     this.xAxisTop.selectAll('line').attr('stroke-opacity', 0)
-  }
-  generatePlotDataButton = () => {
-    const { maxYAxisWidth, height, matrixHeight } = this
-
-    const xAxisBottomYCoordinate =
-      height > 0 && height < matrixHeight
-        ? height - this.cardSize * 1.5
-        : matrixHeight
-    const button = this.svg
-      .append('g')
-      .attr('class', 'PlotDataButton')
-      .attr(
-        'transform',
-        `translate(${-(
-          maxYAxisWidth + this.halfCardSize
-        )},${xAxisBottomYCoordinate})`
-      )
-    button
-      .append('rect')
-      .attr('width', maxYAxisWidth + margin.left)
-      .attr('height', this.cardSize)
-      .attr('x', 0)
-      .attr('y', -this.halfCardSize + 2)
-      .style('fill', this.widthBasedFill)
-      .attr('class', 'Button')
-    button
-      .append('text')
-      .text('PLOT DATA')
-      .attr('x', maxYAxisWidth / 2 - this.cardSize)
-      .attr('y', this.halfCardSize / 4)
-      .style('fill', DARK_GREY)
-      .attr('font-size', this.halfCardSize)
-      .attr('font-family', "'Helvetica Neue', Helvetica, Arial, sans-serif")
-      .style('text-anchor', 'start')
-      .attr('class', 'Button')
-      .on('mouseover', function (d) {
-        d3.select(this).classed('text-hover', true)
-      })
-      .on('mouseout', function (d) {
-        d3.select(this).classed('text-hover', false)
-      })
-      .on('click', function (d, i) {
-        alert('This feature is not yet available.')
-      })
   }
 
   get widthBasedFill() {
@@ -547,7 +503,6 @@ export default class Matrix {
       this.height > 0 && this.height < this.matrixHeight
         ? this.height - this.cardSize * 2 + 1
         : this.matrixHeight - this.halfCardSize + 1
-
     this.generateSpace({
       width: this.matrixWidth + this.maxYAxisWidth,
       height: this.cardSize + 2,

--- a/views/pages/GraphPage.jsx
+++ b/views/pages/GraphPage.jsx
@@ -213,20 +213,18 @@ const GraphPage = () => {
           View Table
         </Button>
       </Box>
+      <div className="Matrix">
+        <div className="graph" ref={el} />
+      </div>
       <div>
-        <div className="Matrix">
-          <div className="graph" ref={el} />
-        </div>
-        <div>
-          <Button
-            variant="fab"
-            onClick={downloadPng}
-            id="downloadPng"
-            focusRipple={true}
-          >
-            <Save />
-          </Button>
-        </div>
+        <Button
+          variant="fab"
+          onClick={downloadPng}
+          id="downloadPng"
+          focusRipple={true}
+        >
+          <Save />
+        </Button>
       </div>
       <Dialog modal={false} open={openStat} onClose={closeStat}>
         <DialogContent>


### PR DESCRIPTION
This pr fixes a bug where the matrix page crashes if no data is returned from the server. 
The issue is with certain variables calculating to numbers below 0 that cause a crash with d3.

On the graph page I moved the save button out from the Matrix div.
I made small alignment tweaks to display the numbered days better. 
There's a button that when clicked throws an alert about a feature that will be implemented in the future, this felt unnecessary to have, I removed it.



<img width="976" alt="Screenshot 2024-02-19 at 3 06 42 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/5e139035-86c5-4f10-a2bf-3f8caf64c7db">
<img width="969" alt="Screenshot 2024-02-19 at 3 06 54 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/0e1248a4-2b2f-46ac-986d-41a12680e77e">
