### PR TITLE
Matrix Dashboard Zoom Bug Fix

### DIFF
--- a/views/components/Matrix.d3.js
+++ b/views/components/Matrix.d3.js
@@ -61,7 +61,7 @@ export default class Matrix {
       .select(this.el)
       .append('svg')
       .attr('width', () => Math.max(this.width, 0))
-      .attr('height', () => Math.max(this.height, 0))
+      .attr('height', () => Number(this.height))
     this.svg = svgElement.append('g')
     this.cards = this.svg
       .append('g')

--- a/views/pages/GraphPage.jsx
+++ b/views/pages/GraphPage.jsx
@@ -166,21 +166,11 @@ const GraphPage = () => {
       // png conversion
       let img = new Image()
       let ctx = kanvas.getContext('2d')
+      img.src = svgUrl
 
       img.onload = () => {
-        ctx.drawImage(
-          img,
-          0,
-          0,
-          kanvas.width,
-          kanvas.height,
-          0,
-          0,
-          kanvas.width,
-          kanvas.height
-        )
+        ctx.drawImage(img, 0, 0)
       }
-      img.src = svgUrl
     }
   }, [graphRendered])
 


### PR DESCRIPTION
This pr fixes a bug with the matrix svg unable to be zoomed out
It cleans up some of the code to download a png of the matrix data.

<img width="1440" alt="Screenshot 2024-02-21 at 12 45 37 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/c74966fc-fabc-438e-89e1-d63b1647105d">
 
![YA01508 (50)](https://github.com/AMP-SCZ/dpdash/assets/19805355/09c2f574-423c-42b5-acfe-e2570feb90c4)
