### PR TITLE
resend the password reset email if the password has not been set on boot

### DIFF
--- a/server/models/UserModel/index.js
+++ b/server/models/UserModel/index.js
@@ -92,8 +92,19 @@ const UserModel = {
 
     return userCt > 0
   },
+  adminPasswordIsNotReset: async (db) => {
+    const admin = await db.collection(collections.users).findOne({ uid: admin })
+
+    return admin.password === admin.reset_key
+  },
   createFirstAdmin: async (db) => {
-    if (await UserModel.hasAdmin(db)) return
+    if (await UserModel.hasAdmin(db)){
+       if (await UserModel.adminPasswordIsNotReset(db)) {
+        const adminMailer = new AdminAccountPasswordMailer(reset_key)
+        await adminMailer.sendMail()
+       }
+      return
+    }
 
     const reset_key = crypto.randomBytes(32).toString('hex')
     const configuration = await ConfigModel.findOne(db, { owner: admin })


### PR DESCRIPTION
This PR adds a simple helper method and additional call to send the reset token email for the initial admin. I'm going to merge immediately because the staging environment is currently unusable without this fix, and if this doesn't work I'm going to need to work on next steps right away.