### PR TITLE
Fix  $set operator

### DIFF
--- a/server/models/ChartsModel/ChartsModel.test.js
+++ b/server/models/ChartsModel/ChartsModel.test.js
@@ -23,14 +23,14 @@ describe(chartsListQuery, () => {
         },
       },
       {
-        $set: {
+        $addFields: {
           chart_id: {
             $toString: '$_id',
           },
         },
       },
       {
-        $set: {
+        $addFields: {
           favorite: {
             $in: ['$chart_id', ['1', '2']],
           },

--- a/server/models/ChartsModel/index.js
+++ b/server/models/ChartsModel/index.js
@@ -64,9 +64,9 @@ export const chartsListQuery = (user, queryParams) => {
     {
       $match: searchQuery,
     },
-    { $set: { chart_id: { $toString: id } } },
+    { $addFields: { chart_id: { $toString: id } } },
     {
-      $set: {
+      $addFields: {
         favorite: { $in: [idKey, favoriteCharts || []] },
       },
     },


### PR DESCRIPTION
DocumentDB is missing support for the $set aggregation field. We replace it with $addFields an operator that is supported.