### PR TITLE
Additional compatibility updates

### DIFF
--- a/server/controllers/chartsController/chartsController.test.js
+++ b/server/controllers/chartsController/chartsController.test.js
@@ -179,16 +179,19 @@ describe('chartsController', () => {
               ...chart3,
               chartOwner: restOfUser,
               favorite: true,
+              chart_id: chart3._id.toString(),
             },
             {
               ...chart2,
               chartOwner: restOfUser,
               favorite: false,
+              chart_id: chart2._id.toString(),
             },
             {
               ...chart1,
               chartOwner: restOfUser,
               favorite: false,
+              chart_id: chart1._id.toString(),
             },
           ],
         })
@@ -252,8 +255,18 @@ describe('chartsController', () => {
 
         expect(response.json).toHaveBeenCalledWith({
           data: [
-            { ...chart3, chartOwner: restOfanotherUser, favorite: true },
-            { ...chart1, chartOwner: restOfUser, favorite: false },
+            {
+              ...chart3,
+              chartOwner: restOfanotherUser,
+              favorite: true,
+              chart_id: chart3._id.toString(),
+            },
+            {
+              ...chart1,
+              chartOwner: restOfUser,
+              favorite: false,
+              chart_id: chart1._id.toString(),
+            },
           ],
         })
       })

--- a/server/models/ChartsModel/ChartsModel.test.js
+++ b/server/models/ChartsModel/ChartsModel.test.js
@@ -37,9 +37,6 @@ describe(chartsListQuery, () => {
         },
       },
       {
-        $unset: 'chart_id',
-      },
-      {
         $sort: {
           favorite: -1,
           title: 1,

--- a/server/models/ChartsModel/index.js
+++ b/server/models/ChartsModel/index.js
@@ -70,7 +70,6 @@ export const chartsListQuery = (user, queryParams) => {
         favorite: { $in: [idKey, favoriteCharts || []] },
       },
     },
-    { $unset: chartId },
     ...sort,
   ]
 }

--- a/server/models/ConfigModel/index.js
+++ b/server/models/ConfigModel/index.js
@@ -27,12 +27,11 @@ const ConfigModel = {
 
     return value
   },
-  index: async (db, userId) => {
-    return await db
+  index: async (db, userId) =>
+    await db
       .collection(collections.configs)
       .aggregate(loadAllConfigurationsMongoQuery(userId))
-      .toArray()
-  },
+      .toArray(),
   create: async (db, configAttributes) => {
     const { insertedId } = await db
       .collection(collections.configs)
@@ -55,8 +54,7 @@ const loadAllConfigurationsMongoQuery = (userId) => {
   const users = 'users'
   const owner = 'owner'
   const uid = 'uid'
-  const resultPropertyName = 'ownerUser'
-  const $display_name = '$display_name'
+  const configOwner = 'ownerUser'
 
   return [
     {
@@ -69,17 +67,21 @@ const loadAllConfigurationsMongoQuery = (userId) => {
         from: users,
         localField: uid,
         foreignField: owner,
-        pipeline: [
-          {
-            $project: {
-              icon: 1,
-              uid: 1,
-              name: $display_name,
-              _id: 0,
-            },
-          },
-        ],
-        as: resultPropertyName,
+        as: configOwner,
+      },
+    },
+    {
+      $project: {
+        _id: 1,
+        name: 1,
+        type: 1,
+        created: 1,
+        owner: 1,
+        readers: 1,
+        config: 1,
+        'ownerUser.0.uid': 1,
+        'ownerUser.0.display_name': 1,
+        'ownerUser.0.icon': 1,
       },
     },
   ]


### PR DESCRIPTION
There are other compatibility updates. The $lookup operator from document db is limited to just one join, moved the pipeline stage further down to fix this collision.
```python
error
: 
"Aggregation stage not supported: '$lookup on multiple join conditions and uncorrelated subquery'"

Document DB has $unset outside of a aggregation, this pr removes that stage. 
error
: 
"Unrecognized pipeline stage name: '$unset'"
```