### PR TITLE
Participant filter by site returns an error

### DIFF
--- a/views/hooks/useParticipantsList.jsx
+++ b/views/hooks/useParticipantsList.jsx
@@ -27,7 +27,7 @@ export default function useParticipantsList() {
     const sortParams = {
       ...(sortBy ? { sortBy } : {}),
       ...(sortDirection ? { sortDirection } : {}),
-      ...(formFilters.searchParticipants.length
+      ...(formFilters.searchParticipants?.length
         ? {
             searchParticipants: normalizeSearchParticipants(
               formFilters.searchParticipants


### PR DESCRIPTION
closes #660 

When a user requests participants by site the request is not made. This pr fixes that.