### PR TITLE
665 handle null consent date

### DIFF
--- a/server/controllers/api/assessmentDayDataController/assessmentDayDataController.test.js
+++ b/server/controllers/api/assessmentDayDataController/assessmentDayDataController.test.js
@@ -29,6 +29,8 @@ describe('assessmentDayDataController', () => {
         end: '4',
         extension: '.csv',
         time_end: '4',
+        Consent: '2020-01-02',
+        Active: 1,
       }
       let appDb
 
@@ -111,6 +113,8 @@ describe('assessmentDayDataController', () => {
           end: '4',
           extension: '.csv',
           time_end: '4',
+          Active: 1,
+          Consent: new Date('2020-01-02'),
           dayData: [
             { day: 1, var1: 1, var2: 2, var3: 'str' },
             {
@@ -253,6 +257,7 @@ describe('assessmentDayDataController', () => {
           end: '12',
           extension: '.csv',
           time_end: '12',
+          Consent: null,
           dayData: [
             {
               day: 1,
@@ -323,7 +328,6 @@ describe('assessmentDayDataController', () => {
             {
               projection: {
                 _id: 0,
-                'participants.Consent': 0,
                 'participants.synced': 0,
               },
             }
@@ -334,6 +338,7 @@ describe('assessmentDayDataController', () => {
           participants: [
             {
               Active: 1,
+              Consent: new Date('2020-01-02'),
               study: 'study',
               participant: 'participant',
             },

--- a/server/controllers/participantsController/participantsController.test.js
+++ b/server/controllers/participantsController/participantsController.test.js
@@ -4,6 +4,7 @@ import {
   createResponse,
   createUser,
   createMetadataParticipant,
+  createAssessmentDayData,
 } from '../../../test/fixtures'
 import { collections } from '../../utils/mongoCollections'
 
@@ -18,11 +19,13 @@ describe('ParticipantsController', () => {
       beforeEach(async () => {
         await appDb.createCollection(collections.metadata)
         await appDb.createCollection(collections.users)
+        await appDb.createCollection(collections.assessmentDayData)
       })
 
       afterEach(async () => {
         await appDb.collection(collections.users).drop()
         await appDb.collection(collections.metadata).drop()
+        await appDb.collection(collections.assessmentDayData).drop()
       })
       afterAll(async () => {
         await appDb.dropDatabase()
@@ -88,6 +91,63 @@ describe('ParticipantsController', () => {
             ],
           },
         ])
+        await appDb.collection(collections.assessmentDayData).insertMany([
+          createAssessmentDayData({
+            study: 'CA',
+            participant: 'CA00063',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'CA',
+            participant: 'CA00064',
+            dayData: [
+              {
+                day: 15
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA00037',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA29023',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA00015',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA01508',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+        ])
+
         const request = createRequestWithUser(
           {
             app: { locals: { appDb } },
@@ -222,6 +282,62 @@ describe('ParticipantsController', () => {
               result,
             ],
           },
+        ])
+        await appDb.collection(collections.assessmentDayData).insertMany([
+          createAssessmentDayData({
+            study: 'CA',
+            participant: 'CA00063',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'CA',
+            participant: 'CA00064',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA00037',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA29023',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA00015',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
+          createAssessmentDayData({
+            study: 'YA',
+            participant: 'YA01508',
+            dayData: [
+              {
+                day: 49
+              }
+            ]
+          }),
         ])
         const request = createRequestWithUser(
           {

--- a/server/models/ParticipantsModel/index.js
+++ b/server/models/ParticipantsModel/index.js
@@ -21,7 +21,7 @@ const ParticipantsModel = {
         },
         {
           $group: {
-            _id: '$subject',
+            _id: '$participant',
             daysInStudy: {
               $max: '$dayData.day'
             }

--- a/server/models/ParticipantsModel/index.js
+++ b/server/models/ParticipantsModel/index.js
@@ -2,20 +2,42 @@ import { collections } from '../../utils/mongoCollections'
 import { ASC } from '../../constants'
 import { ALL_SUBJECTS_MONGO_PROJECTION, STUDIES_TO_OMIT } from '../../constants'
 
-const $Consent = '$Consent'
 const participant = 'participant'
 const $participant = '$participant'
 const $participants = '$participants'
-const $synced = '$synced'
-const oneDayInSeconds = 86400000
-const today = new Date()
 
 const ParticipantsModel = {
-  index: async (db, user, queryParams) =>
-    await db
+  index: async (db, user, queryParams) => {
+    const participants =  await db
       .collection(collections.metadata)
       .aggregate(allParticipantsQuery(user, queryParams))
-      .toArray(),
+      .toArray()
+
+    const maxDaysInStudy = await db
+      .collection(collections.assessmentDayData)
+      .aggregate([
+        {
+          $unwind: '$dayData'
+        },
+        {
+          $group: {
+            _id: '$subject',
+            daysInStudy: {
+              $max: '$dayData.day'
+            }
+          }
+        }
+      ])
+      .toArray()
+
+    const maxDaysInStudyByParticipant = maxDaysInStudy.reduce((map, participantDaysInStudy) => {
+        map[participantDaysInStudy._id] = participantDaysInStudy.daysInStudy
+        return map
+      }, {})
+
+    return participants
+      .map(participant => ({...participant, daysInStudy: maxDaysInStudyByParticipant[participant.participant]}))
+  },
   allForAssessment: async (db, chart, filtersService) => {
     const { filterQueries } = filtersService
     const query = {
@@ -111,21 +133,6 @@ const allParticipantsQuery = (user, queryParams) => {
         study: 1,
         participant: 1,
         synced: 1,
-        daysInStudy: {
-          $cond: {
-            if: { $ne: [$synced, null] },
-            then: {
-              $floor: {
-                $divide: [{ $subtract: [$synced, $Consent] }, oneDayInSeconds],
-              },
-            },
-            else: {
-              $floor: {
-                $divide: [{ $subtract: [today, $Consent] }, oneDayInSeconds],
-              },
-            },
-          },
-        },
       },
     },
   ]

--- a/server/models/UserModel/index.js
+++ b/server/models/UserModel/index.js
@@ -101,8 +101,7 @@ const UserModel = {
     if (await UserModel.hasAdmin(db)){
        if (await UserModel.adminPasswordIsNotReset(db)) {
         const adminUser = await UserModel.findOne(db, { uid: admin })
-        const adminMailer = new AdminAccountPasswordMailer(adminUser.reset_key)
-        await adminMailer.sendMail()
+        await UserModel.sendResetPasswordKey(adminUser.reset_key)
        }
       return
     }
@@ -132,6 +131,9 @@ const UserModel = {
       reset_key,
     })
 
+    await UserModel.sendResetPasswordKey(reset_key)
+  },
+  sendResetPasswordKey: async (reset_key) => {
     if (process.env.NODE_ENV === 'development')
       console.log(`RESET KEY: ${reset_key}`)
     else {

--- a/views/components/Matrix.d3.js
+++ b/views/components/Matrix.d3.js
@@ -352,14 +352,14 @@ export default class Matrix {
 
   generateXAxisForDatesData = () => {
     const xAxisForDatesData = []
-    const startDate = stringToDate(this.consentDate, 'yyyy-mm-dd', '-')
+    const startDate = this.consentDate ? stringToDate(this.consentDate, 'yyyy-mm-dd', '-') : null
     const firstDay = this.startDay - 1 //Consent date is 1
     for (let i = firstDay; i < this.lastDayForFilter; i++) {
       const day = i + 1
 
-      if (startDate.getDay() == 0 || startDate.getDay() == 6) {
+      if (startDate && startDate.getDay() == 0 || startDate.getDay() == 6) {
         xAxisForDatesData.push({ day, marker: 'S' })
-      } else if (startDate.getDay() == 3) {
+      } else if (startDate && startDate.getDay() == 3) {
         const month = startDate.getMonth() + 1
         const localeDate = `${month}/${startDate.getDate()}/${startDate.getFullYear()}`
 


### PR DESCRIPTION
This PR fixes initialization of the participant consent date from the metadata, including when the date is missing or set to an invalid value. It also handle the days in study on the participants view by looking at the greatest `day` value in the `dayData` array. I added an unrelated fix to initializing the admin account in development, since it was causing issues for me locally.