### PR TITLE
Fix chart filter dropdown height

### DIFF
--- a/views/forms/DropdownCheckboxGroup/index.jsx
+++ b/views/forms/DropdownCheckboxGroup/index.jsx
@@ -6,7 +6,7 @@ const ITEM_PADDING_TOP = 8;
 const MenuProps = {
   PaperProps: {
     style: {
-      maxHeight: ITEM_HEIGHT + ITEM_PADDING_TOP,
+      maxHeight: ITEM_HEIGHT * 10.5 + ITEM_PADDING_TOP,
       width: 250,
     },
   },


### PR DESCRIPTION
Add back multiplier to dropdown checkbox height, apparently it applies to the height of the dropdown not the input