### PR TITLE
support study-level matrix route when subject is unspecified

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom'
+
+// Mock the SVGElement and CanvasElement methods that we use which are not
+// implemented by JSDOM
+Object.defineProperty(global.SVGElement.prototype, 'getBBox', {
+  writable: true,
+  value: jest.fn().mockReturnValue({
+    x: 0,
+    y: 0,
+  }),
+});
+
+Object.defineProperty(global.HTMLCanvasElement.prototype, 'getContext', {
+  value: jest.fn()
+})

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -308,3 +308,66 @@ export const createAssessmentDayData = (overrides = {}) => ({
   daysInStudy: overrides.dayData ? Math.max(...overrides.dayData.map(dayData => dayData.day)) : 0,
   ...overrides,
 })
+
+export const createGraphDataResponse = (overrides = {}) => (
+  {
+    "subject": {
+        "sid": "LA48928",
+        "project": "LA"
+    },
+    "graph": {
+        "matrixData": [
+            {
+                "analysis": "phone_power_activityScores_hourly",
+                "data": [],
+                "label": "Day",
+                "variable": "day",
+                "stat": [],
+                "range": [
+                    1,
+                    "3655"
+                ],
+                "text": true,
+                "color": [
+                    "#f7fcf5",
+                    "#e5f5e0",
+                    "#c7e9c0",
+                    "#a1d99b",
+                    "#74c476",
+                    "#41ab5d",
+                    "#238b45",
+                    "#006d2c",
+                    "#00441b"
+                ],
+                "category": "phone_use"
+            }
+        ],
+        "configurations": [
+            {
+                "range": [
+                    1,
+                    "3655"
+                ],
+                "text": true,
+                "variable": "day",
+                "label": "Day",
+                "color": [
+                    "#f7fcf5",
+                    "#e5f5e0",
+                    "#c7e9c0",
+                    "#a1d99b",
+                    "#74c476",
+                    "#41ab5d",
+                    "#238b45",
+                    "#006d2c",
+                    "#00441b"
+                ],
+                "category": "phone_use",
+                "analysis": "phone_power_activityScores_hourly"
+            },
+        ],
+        "consentDate": "2022-06-02T00:00:00.000Z"
+    },
+    ...overrides
+  }
+)

--- a/views/components/Graph/Graph.test.jsx
+++ b/views/components/Graph/Graph.test.jsx
@@ -1,0 +1,39 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { createGraphDataResponse, createUser } from '../../../test/fixtures'
+import api from '../../api'
+import { Graph } from '.'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockGraphDataResponse = createGraphDataResponse({
+  subject: {
+    sid: "subject",
+    project: "study"
+  } 
+})
+describe('Graph', () => {
+  it('calls the graph data API endpoint for the given participant', async () => {
+    const mockApi = jest.spyOn(api.dashboard, 'load')
+    mockApi.mockResolvedValue(mockGraphDataResponse)
+
+    render(
+      <MemoryRouter>
+        <Graph user={createUser()} study={"study"} subject={"subject"} theme={{}} setNotification={jest.fn()} />
+      </MemoryRouter>
+    )
+    await waitFor(() => {
+      expect(api.dashboard.load).toHaveBeenCalledWith("study", "subject")
+    })
+  })
+  it('renders the graph', async () => {
+    const mockApi = jest.spyOn(api.dashboard, 'load')
+    mockApi.mockResolvedValue(mockGraphDataResponse)
+    
+    render(
+      <MemoryRouter>
+        <Graph user={createUser()} study={"study"} subject={"subject"} theme={{}} setNotification={jest.fn()} />
+      </MemoryRouter>
+    )
+    const graphElement = await screen.findByTestId("graph")
+    expect(graphElement.firstChild).toBeInTheDocument()
+  })
+})

--- a/views/components/Graph/index.jsx
+++ b/views/components/Graph/index.jsx
@@ -1,0 +1,189 @@
+import React, { createRef, useRef } from 'react'
+import FileSaver from 'file-saver'
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  Dialog,
+  Typography
+} from '@mui/material'
+import { Save, Functions } from '@mui/icons-material'
+
+import Matrix from '../Matrix.d3'
+import GraphPageTable from '../GraphPageTable'
+import api from '../../api'
+import { Link } from 'react-router-dom'
+import { routes } from '../../routes/routes'
+import { fontSize } from '../../../constants'
+
+const cardSize = 20
+
+export const Graph = ({ study, subject, user, theme, setNotification }) => {
+  const canvasRef = useRef()
+  const graphRef = createRef()
+  const [openStat, setOpenStat] = React.useState(false)
+  const [graph, setGraph] = React.useState({
+    configurations: [],
+    consentDate: '',
+    matrixData: [],
+  })
+  const [dayData, setDayData] = React.useState({
+    startFromTheLastDay: false,
+    startDay: 1,
+    lastDay: null,
+    maxDay: 1,
+  })
+
+  const fetchGraph = async () => await api.dashboard.load(study, subject)
+  const downloadPng = () =>
+    canvasRef.current.toBlob((blob) => {
+      FileSaver.saveAs(blob, `${subject}.png`)
+    })
+
+  const closeStat = () => setOpenStat(false)
+  const updateMaxDay = (graph) => {
+    const daysParticipated = graph.matrixData
+      .flatMap(({ data }) => data)
+      .map(({ day }) => day)
+    const calculateMaxDay = Math.max(...daysParticipated)
+
+    setDayData({ ...dayData, maxDay: calculateMaxDay || 1 })
+  }
+
+  const onMount = async () => {
+    try {
+      const graphData = await fetchGraph()
+
+      setGraph(graphData.graph)
+      updateMaxDay(graphData.graph)
+      renderMatrix()
+
+      if (!HTMLCanvasElement.prototype.toBlob) {
+        Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+          value: function (callback, type, quality) {
+            var binStr = atob(this.toDataURL(type, quality).split(',')[1]),
+              len = binStr.length,
+              arr = new Uint8Array(len)
+
+            for (var i = 0; i < len; i++) {
+              arr[i] = binStr.charCodeAt(i)
+            }
+            callback(new Blob([arr], { type: type || 'image/png' }))
+          },
+        })
+      }
+    } catch (e) {
+      setNotification({ open: true, message: e.message })
+    }
+  }
+  const renderMatrix = () => {
+    if (graphRef.current.firstChild) {
+      graphRef.current.removeChild(graphRef.current.firstChild)
+    }
+    if (!graph.matrixData || Object.keys(graph.matrixData).length == 0) {
+      return
+    }
+    const matrixProps = {
+      id: 'matrix',
+      type: 'matrix',
+      data: graph.matrixData,
+      cardSize,
+      study,
+      subject,
+      consentDate: graph.consentDate,
+      configuration: graph.configurations,
+      startFromTheLastDay: dayData.startFromTheLastDay,
+      startDay: dayData.startDay,
+      lastDay: dayData.lastDay,
+      maxDay: dayData.maxDay,
+      user: user.uid,
+    }
+
+    graphRef.current = new Matrix(graphRef.current, matrixProps)
+
+    graphRef.current.create(graph.matrixData)
+  }
+
+  React.useEffect(() => {
+    onMount()
+  }, [])
+
+  React.useEffect(() => {
+    if (!graphRef.current) {
+      return
+    }
+
+    let updatedSvgElement = graphRef.current.lastChild
+    if (updatedSvgElement) {
+      let svgString = new XMLSerializer().serializeToString(updatedSvgElement)
+
+      const kanvas = canvasRef.current
+      kanvas.width = updatedSvgElement.getBBox().width
+      kanvas.height = updatedSvgElement.getBBox().height
+
+      let svgUrl =
+        'data:image/svg+xml; charset=utf8, ' + encodeURIComponent(svgString.replace('<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">', `<svg xmlns="http://www.w3.org/2000/svg" width="${kanvas.width}" height="${kanvas.height}">`))
+
+      // png conversion
+      let img = new Image(kanvas.width, kanvas.height)
+      let ctx = kanvas.getContext('2d')
+      img.src = svgUrl
+
+      img.onload = () => {
+        ctx.drawImage(img, 0, 0)
+      }
+    }
+  }, [graphRef])
+
+  React.useEffect(() => {
+    renderMatrix()
+  }, [graph.matrixData])
+
+  return (
+    <Box>
+      <Typography
+        component={Link}
+        to={routes.dashboard(study, subject)}
+        sx={{ fontSize: fontSize[20], color: 'text.primary' }}
+      >
+        {subject}
+      </Typography>
+      <Button
+        aria-label="Open Stat"
+        onClick={() => setOpenStat(true)}
+        endIcon={<Functions />}
+      >
+        View Table
+    </Button>
+      <div className="Matrix" style={{height: '65vh'}}>
+        <div className="graph" ref={graphRef} style={{height:'65vh', overflow: 'scroll'}} />
+      </div>
+      <div>
+        <Button
+          variant="fab"
+          onClick={downloadPng}
+          id="downloadPng"
+          focusRipple={true}
+        >
+          <Save />
+        </Button>
+      </div>
+      <Dialog modal={false} open={openStat} onClose={closeStat}>
+        <DialogContent>
+          <GraphPageTable
+            matrixData={graph.matrixData}
+            maxDay={dayData.maxDay}
+            theme={theme}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button color="secondary" onClick={closeStat}>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <canvas ref={canvasRef} style={{display: 'none'}}/>
+    </Box>
+  )
+}

--- a/views/components/Graph/index.jsx
+++ b/views/components/Graph/index.jsx
@@ -57,7 +57,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
 
       setGraph(graphData.graph)
       updateMaxDay(graphData.graph)
-      renderMatrix()
+      renderMatrix(graphData.graph)
 
       if (!HTMLCanvasElement.prototype.toBlob) {
         Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
@@ -77,11 +77,11 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
       setNotification({ open: true, message: e.message })
     }
   }
-  const renderMatrix = () => {
-    if (graphRef.current.firstChild) {
+  const renderMatrix = (graph) => {
+    if (graphRef.current && graphRef.current.firstChild) {
       graphRef.current.removeChild(graphRef.current.firstChild)
     }
-    if (!graph.matrixData || Object.keys(graph.matrixData).length == 0) {
+    if (!graph || !graph.matrixData || Object.keys(graph.matrixData).length == 0) {
       return
     }
     const matrixProps = {
@@ -137,7 +137,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
   }, [graphRef])
 
   React.useEffect(() => {
-    renderMatrix()
+    renderMatrix(graph)
   }, [graph.matrixData])
 
   return (
@@ -157,7 +157,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
         View Table
     </Button>
       <div className="Matrix" style={{height: '65vh'}}>
-        <div className="graph" ref={graphRef} style={{height:'65vh', overflow: 'scroll'}} />
+        <div data-testid="graph" className="graph" ref={graphRef} style={{height:'65vh', overflow: 'scroll'}} />
       </div>
       <div>
         <Button
@@ -183,7 +183,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
           </Button>
         </DialogActions>
       </Dialog>
-      <canvas ref={canvasRef} style={{display: 'none'}}/>
+      <canvas key={`${study}-${subject}`} ref={canvasRef} style={{display: 'none'}}/>
     </Box>
   )
 }

--- a/views/components/Matrix.d3.js
+++ b/views/components/Matrix.d3.js
@@ -239,7 +239,7 @@ export default class Matrix {
     for (let i = firstDay; i < this.lastDayForFilter; i++) {
       const day = i + 1
 
-      if (startDate && startDate.getDay() == 0 || startDate.getDay() == 6) {
+      if (startDate && (startDate.getDay() == 0 || startDate.getDay() == 6)) {
         xAxisForDatesData.push({ day, marker: 'S' })
       } else if (startDate && startDate.getDay() == 3) {
         const month = startDate.getMonth() + 1
@@ -252,7 +252,9 @@ export default class Matrix {
       } else {
         xAxisForDatesData.push({ day, marker: 'N/A' })
       }
-      startDate.setDate(startDate.getDate() + 1)
+      if (startDate) {
+        startDate.setDate(startDate.getDate() + 1)
+      }
     }
 
     return xAxisForDatesData

--- a/views/components/Matrix.d3.js
+++ b/views/components/Matrix.d3.js
@@ -52,12 +52,13 @@ export default class Matrix {
   validDay = (d) => d.day >= this.startDay && d.day <= this.lastDayForFilter
   create = (data) => {
     this.data = data
+    const calculatedHeight = data.length * this.cardSize + margin.top + margin.bottom
 
     const svgElement = d3
       .select(this.el)
       .append('svg')
       .attr('width', () => '100%')
-      .attr('height', () => data.length * this.cardSize + margin.top + margin.bottom)
+      .attr('height', () => calculatedHeight)
     this.svg = svgElement.append('g')
     this.cards = this.svg
       .append('g')

--- a/views/components/Matrix.d3.js
+++ b/views/components/Matrix.d3.js
@@ -24,9 +24,6 @@ export default class Matrix {
     this.startDay = props.startDay
     this.lastDay = props.lastDay
     this.maxDay = props.maxDay
-    this.initialHeight = props.height
-    this.height = props.height - margin.top - margin.bottom
-    this.width = props.width - margin.right
     this.study = props.study
     this.subject = props.subject
     this.consentDate = props.consentDate
@@ -60,7 +57,7 @@ export default class Matrix {
       .select(this.el)
       .append('svg')
       .attr('width', () => '100%')
-      .attr('height', () => '100%')
+      .attr('height', () => data.length * this.cardSize + margin.top + margin.bottom)
     this.svg = svgElement.append('g')
     this.cards = this.svg
       .append('g')
@@ -216,29 +213,6 @@ export default class Matrix {
     if (this.startFromTheLastDay) {
       this.update()
     }
-
-    this.maxYScroll = Math.max(
-      this.height,
-      this.matrixHeight + margin.bottom + margin.top
-    )
-    this.maxXScroll = Math.max(
-      this.width,
-      this.matrixWidth + this.maxYAxisWidth + margin.left
-    )
-    const zoom = d3
-      .zoom()
-      .scaleExtent([1, 5])
-      .translateExtent([
-        [0, 0],
-        [this.maxXScroll, this.maxYScroll],
-      ])
-      .on('zoom', this.zoomed)
-    //for some reason, vertical scrolling works better with these statements. investigate.
-    this.svg
-      .call(zoom, d3.zoomIdentity)
-      .on('wheel.zoom', this.pan)
-      .on('mousewheel.zoom', this.pan)
-      .on('DOMMouseScroll.zoom', this.pan)
   }
 
   adjustYAxisLeft = () => {
@@ -248,98 +222,6 @@ export default class Matrix {
       .text((d) => d.label)
       .attr('font-size', this.halfCardSize)
       .style('fill', DARK_GREY)
-  }
-
-  scaleAxes = (transform) => {
-    this.yAxisLeft.call(
-      this.yAxisLinear.scale(transform.rescaleY(this.yScaleLinear))
-    )
-    this.xAxisBottom.call(
-      this.xAxisLinearBottom.scale(transform.rescaleX(this.xScaleLinearBottom))
-    )
-    this.xAxisTop.call(
-      this.xAxisLinearTop.scale(transform.rescaleX(this.xScaleLinearTop))
-    )
-    this.adjustYAxisLeft()
-  }
-
-  zoomed = () => {
-    const sourceEvent = d3.event.sourceEvent
-    const eventTransform = d3.event.transform
-    sourceEvent?.preventDefault()
-
-    this.cards.attr('transform', eventTransform)
-    this.categoryMarker.attr(
-      'transform',
-      `translate(${eventTransform.x - this.maxYAxisWidth},${
-        eventTransform.y
-      }) scale(${eventTransform.k})`
-    )
-
-    this.scaleAxes(eventTransform)
-    this.filteredXAxisTop()
-  }
-
-  pan = () => {
-    const sourceEvent = d3.event
-    sourceEvent.preventDefault()
-
-    const transformAttr = this.cards.attr('transform')
-    const transformAttrArray = transformAttr
-      .substring(transformAttr.indexOf('(') + 1, transformAttr.indexOf(')'))
-      .split(',')
-
-    const x = parseInt(transformAttrArray[0])
-    const y = parseInt(transformAttrArray[1])
-
-    const mouseDelta = sourceEvent.wheelDelta || sourceEvent.detail
-    const deltaX =
-      sourceEvent.deltaX ||
-      -sourceEvent.wheelDeltaX ||
-      -(sourceEvent.axis == 1 ? mouseDelta : 0)
-    const deltaY =
-      sourceEvent.deltaY ||
-      -sourceEvent.wheelDeltaY ||
-      -(sourceEvent.axis == 2 ? mouseDelta : 0)
-    let dx = -deltaX + x
-    let dy = -deltaY + y
-
-    //Disable zoom-in upon wheeling
-    const eventTransform = d3.zoomIdentity.translate(dx, dy).scale(1)
-    let transformation = eventTransform.scale(1 / eventTransform.k)
-    const maxDy = (this.matrixHeight - this.height + margin.top) * -1
-    const maxDx =
-      (this.matrixWidth - this.width + this.maxYAxisWidth + margin.left) * -1
-
-    if (
-      dy >= 0 ||
-      this.matrixHeight < this.height ||
-      this.initialHeight === -1
-    ) {
-      dy = 0
-    } else if (dy < maxDy) {
-      dy = maxDy
-    }
-
-    if (this.matrixWidth < this.width || dx > 0) {
-      dx = 0
-    } else if (dx < maxDx) {
-      dx = maxDx
-    }
-
-    this.cards.attr('transform', `translate(${dx},${dy})`)
-    this.categoryMarker.attr(
-      'transform',
-      `translate(${dx - this.maxYAxisWidth},${dy})`
-    )
-
-    transformation = transformation.translate(
-      dx - transformation.x,
-      dy - transformation.y
-    )
-
-    this.scaleAxes(transformation)
-    this.filteredXAxisTop().attr('font-size', this.halfCardSize)
   }
 
   filteredXAxisTop = () => {

--- a/views/pages/GraphPage.jsx
+++ b/views/pages/GraphPage.jsx
@@ -1,60 +1,37 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useOutletContext, useParams } from 'react-router-dom'
-import FileSaver from 'file-saver'
 import {
   Box,
-  Button,
-  DialogActions,
-  DialogContent,
-  Dialog,
+  Divider
 } from '@mui/material'
-import { Save, Functions } from '@mui/icons-material'
 
 import PageHeader from '../components/PageHeader'
 import SelectConfigurationForm from '../components/SelectConfigurationForm'
-import Matrix from '../components/Matrix.d3'
-import GraphPageTable from '../components/GraphPageTable'
+import { Graph } from '../components/Graph'
 import api from '../api'
-
-const cardSize = 20
 
 const GraphPage = () => {
   const { configurations, user, theme, setUser, setNotification } =
     useOutletContext()
-  const el = React.useRef()
-  const canvasRef = React.useRef()
-  const graphRef = React.createRef()
   const { study, subject } = useParams()
-  const [graphRendered, setGraphRendered] = React.useState(0)
-  const [graph, setGraph] = React.useState({
-    configurations: [],
-    consentDate: '',
-    matrixData: [],
-  })
-  const [graphDimensions, setGraphDimensions] = React.useState({
-    height: window.innerHeight,
-    width: window.innerWidth,
-  })
-  const [dayData, setDayData] = React.useState({
-    startFromTheLastDay: false,
-    startDay: 1,
-    lastDay: null,
-    maxDay: 1,
-  })
-  const [openStat, setOpenStat] = React.useState(false)
-  const downloadPng = () =>
-    canvasRef.current.toBlob((blob) => {
-      FileSaver.saveAs(blob, `${subject}.png`)
-    })
+  const [participants, setParticipants] = useState([])
+  useEffect(() => {
+    const asyncEffect = async () => {
+      if (subject && subject !== ':subject') {
+        setParticipants([subject])
+      } else {
+        const participantsRes = await api.participants.all({
+          sortBy: 'participant',
+          sortDirection: 'ASC',
+          studies: [study]
+        })
+        const participants = participantsRes.map((p) => p.participant)
+        setParticipants(participants)
+      }
+    }
 
-  const handleResize = () => {
-    setGraphDimensions({
-      height: window.innerHeight,
-      width: window.innerWidth,
-    })
-  }
-  const closeStat = () => setOpenStat(false)
-  const fetchGraph = async () => await api.dashboard.load(study, subject)
+    asyncEffect()
+  }, [study, subject])
   const updateUserPreferences = async (configurationId) => {
     try {
       const { uid } = user
@@ -66,119 +43,11 @@ const GraphPage = () => {
         },
       }
       const updatedUser = await api.users.update(uid, userAttributes)
-      const graphData = await fetchGraph()
-
       setUser(updatedUser)
-      setGraph(graphData.graph)
-      updateMaxDay(graphData.graph)
     } catch (error) {
       setNotification({ open: true, message: error.message })
     }
   }
-  const updateMaxDay = (graph) => {
-    const daysParticipated = graph.matrixData
-      .flatMap(({ data }) => data)
-      .map(({ day }) => day)
-    const calculateMaxDay = Math.max(...daysParticipated)
-
-    setDayData({ ...dayData, maxDay: calculateMaxDay || 1 })
-  }
-  const onMount = async () => {
-    try {
-      const graphData = await fetchGraph()
-
-      setGraph(graphData.graph)
-      updateMaxDay(graphData.graph)
-      renderMatrix()
-
-      if (!HTMLCanvasElement.prototype.toBlob) {
-        Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
-          value: function (callback, type, quality) {
-            var binStr = atob(this.toDataURL(type, quality).split(',')[1]),
-              len = binStr.length,
-              arr = new Uint8Array(len)
-
-            for (var i = 0; i < len; i++) {
-              arr[i] = binStr.charCodeAt(i)
-            }
-            callback(new Blob([arr], { type: type || 'image/png' }))
-          },
-        })
-      }
-    } catch (e) {
-      setNotification({ open: true, message: e.message })
-    }
-  }
-  const renderMatrix = () => {
-    if (el.current.firstChild) {
-      el.current.removeChild(el.current.firstChild)
-    }
-    if (!graph.matrixData || Object.keys(graph.matrixData).length == 0) {
-      return
-    }
-    const matrixProps = {
-      id: 'matrix',
-      type: 'matrix',
-      width: graphDimensions.width,
-      height: graphDimensions.height,
-      data: graph.matrixData,
-      cardSize,
-      study,
-      subject,
-      consentDate: graph.consentDate,
-      configuration: graph.configurations,
-      startFromTheLastDay: dayData.startFromTheLastDay,
-      startDay: dayData.startDay,
-      lastDay: dayData.lastDay,
-      maxDay: dayData.maxDay,
-      user: user.uid,
-    }
-
-    graphRef.current = new Matrix(el.current, matrixProps)
-
-    graphRef.current.create(graph.matrixData)
-    setGraphRendered(graphRendered + 1)
-  }
-
-  React.useEffect(() => {
-    onMount()
-
-    return () => {
-      window.removeEventListener('resize', handleResize)
-    }
-  }, [])
-
-  React.useEffect(() => {
-    if (!el.current) {
-      console.log('error')
-      return
-    }
-
-    let updatedSvgElement = el.current.lastChild
-    if (updatedSvgElement) {
-      let svgString = new XMLSerializer().serializeToString(updatedSvgElement)
-
-      const kanvas = canvasRef.current
-      kanvas.width = updatedSvgElement.getBBox().width
-      kanvas.height = updatedSvgElement.getBBox().height
-
-      let svgUrl =
-        'data:image/svg+xml; charset=utf8, ' + encodeURIComponent(svgString.replace('<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">', `<svg xmlns="http://www.w3.org/2000/svg" width="${kanvas.width}" height="${kanvas.height}">`))
-
-      // png conversion
-      let img = new Image(kanvas.width, kanvas.height)
-      let ctx = kanvas.getContext('2d')
-      img.src = svgUrl
-
-      img.onload = () => {
-        ctx.drawImage(img, 0, 0)
-      }
-    }
-  }, [graphRendered])
-
-  React.useEffect(() => {
-    renderMatrix()
-  }, [graph.matrixData])
 
   return (
     <Box sx={{ p: '20px' }}>
@@ -197,42 +66,15 @@ const GraphPage = () => {
           onChange={updateUserPreferences}
           currentPreference={user.preferences}
         />
-        <Button
-          aria-label="Open Stat"
-          onClick={() => setOpenStat(true)}
-          endIcon={<Functions />}
-        >
-          View Table
-        </Button>
       </Box>
-      <div className="Matrix">
-        <div className="graph" ref={el} style={{height:'90vh'}} />
-      </div>
-      <div>
-        <Button
-          variant="fab"
-          onClick={downloadPng}
-          id="downloadPng"
-          focusRipple={true}
-        >
-          <Save />
-        </Button>
-      </div>
-      <Dialog modal={false} open={openStat} onClose={closeStat}>
-        <DialogContent>
-          <GraphPageTable
-            matrixData={graph.matrixData}
-            maxDay={dayData.maxDay}
-            theme={theme}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button color="secondary" onClick={closeStat}>
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
-      <canvas ref={canvasRef} style={{display: 'none'}}/>
+        {
+          participants.map((participant) => {
+            return <Box>
+              <Graph key={`${participant}-graph`} study={study} subject={participant} user={user} theme={theme} setNotification={setNotification}/>
+              <Divider/>
+            </Box>
+          })
+        }
     </Box>
   )
 }

--- a/views/pages/GraphPage.jsx
+++ b/views/pages/GraphPage.jsx
@@ -15,23 +15,25 @@ const GraphPage = () => {
     useOutletContext()
   const { study, subject } = useParams()
   const [participants, setParticipants] = useState([])
-  useEffect(() => {
-    const asyncEffect = async () => {
-      if (subject) {
-        setParticipants([subject])
-      } else {
-        const participantsRes = await api.participants.all({
-          sortBy: 'participant',
-          sortDirection: 'ASC',
-          studies: [study]
-        })
-        const participants = participantsRes.map((p) => p.participant)
-        setParticipants(participants)
-      }
+  
+  const fetchParticipants = async () => {
+    if (subject) {
+      setParticipants([subject])
+    } else {
+      const participantsRes = await api.participants.all({
+        sortBy: 'participant',
+        sortDirection: 'ASC',
+        studies: [study]
+      })
+      const participants = participantsRes.map((p) => p.participant)
+      setParticipants(participants)
     }
+  }
 
-    asyncEffect()
+  useEffect(() => {
+    fetchParticipants()
   }, [study, subject])
+  
   const updateUserPreferences = async (configurationId) => {
     try {
       const { uid } = user

--- a/views/pages/GraphPage.jsx
+++ b/views/pages/GraphPage.jsx
@@ -17,7 +17,7 @@ const GraphPage = () => {
   const [participants, setParticipants] = useState([])
   useEffect(() => {
     const asyncEffect = async () => {
-      if (subject && subject !== ':subject') {
+      if (subject) {
         setParticipants([subject])
       } else {
         const participantsRes = await api.participants.all({

--- a/views/routes/index.jsx
+++ b/views/routes/index.jsx
@@ -41,6 +41,7 @@ const Router = () => {
           }
         >
           <Route path={routes.dashboard()} element={<GraphPage />} />
+          <Route path={routes.studyDashboard()} element={<GraphPage />} />
           <Route
             path={routes.configurations}
             element={<ConfigurationsPage />}


### PR DESCRIPTION
<img width="1617" alt="Screenshot 2024-03-15 at 9 57 39 AM" src="https://github.com/AMP-SCZ/dpdash/assets/9471092/6b8ba90c-3b6e-43c3-9543-b0fde9ecfc27">

Rather than adjust anything on the backend I've just refactored the GraphPage to query the study for all participants if the value for the participant is missing, and then query the data endpoint once for each participant. It makes the new `Graph` component stateful, which we usually avoid for non-pages, but simplifies parallelization relative to the old `co(*function` approach on the backend

I also removed a bunch of unused code related to handling scroll/zoom with JS, since the new CSS handles that for us.