### PR TITLE
Tooltip

### DIFF
--- a/views/App.css
+++ b/views/App.css
@@ -3,6 +3,7 @@
   --primary-main: #2196f3;
   --text-secondary: #054da7;
   --dark-transparent-grey: #616161e6;
+  --underline-grey: #0000001f;
 }
 
 .Link--unstyled {

--- a/views/components/BarGraphTooltip/BarGraphTooltip.css
+++ b/views/components/BarGraphTooltip/BarGraphTooltip.css
@@ -3,12 +3,12 @@
 }
 .BarGraphTooltip_data {
   display: grid;
-  width: 175px;
+  max-width: 225px;
   background: var(--dark-transparent-grey);
   color: white;
   padding: 10px;
   border-radius: 10px;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   column-gap: 20px;
   font-size: 14px;
 }
@@ -30,10 +30,16 @@
 }
 .BarGraphTooltip_label {
   grid-column-start: 1;
-  grid-column-end: 4;
+  grid-column-end: 5;
 }
 .BarGraphTooltip_values {
-  grid-column-start: 4;
-  grid-column-end: 5;
+  grid-column-start: 5;
+  grid-column-end: 6;
   text-align: right;
+}
+.BarGraphTooltip_divider {
+  grid-column-start: 1;
+  grid-column-end: 6;
+  height: 3px;
+  background-color: var(--underline-grey);
 }

--- a/views/components/BarGraphTooltip/index.jsx
+++ b/views/components/BarGraphTooltip/index.jsx
@@ -13,26 +13,32 @@ const BarGraphTooltip = ({
 }) => {
   if (!active || !payload?.length) return null
 
+  const siteName = useSiteName ? label : SITE_NAMES[label]
+  const countsTotal = useSiteName
+    ? studyTotals[label].count
+    : studyTotals[SITE_NAMES[label]].count
+  const variableCounts = payload[0].payload.counts
+
   return (
     <div className="BarGraphTooltip">
       {displayLeft ? <div className="arrow-left" /> : null}
       <div className="BarGraphTooltip_data">
-        <div className="BarGraphTooltip_label">{label}</div>
+        <div className="BarGraphTooltip_label">{siteName}</div>
         <div className="BarGraphTooltip_values">Value</div>
-        {payload.map(({ name, value }) => {
+        <span className="BarGraphTooltip_divider" />
+        {payload.map(({ name }) => {
           return (
             <Fragment key={name}>
               <div className="BarGraphTooltip_label">{name}</div>
-              <div className="BarGraphTooltip_values">{value}</div>
+              <div className="BarGraphTooltip_values">
+                {variableCounts[name]}
+              </div>
             </Fragment>
           )
         })}
+        <span className="BarGraphTooltip_divider" />
         <div className="BarGraphTooltip_label">Total</div>
-        <div className="BarGraphTooltip_values">
-          {useSiteName
-            ? studyTotals[label]?.count || null
-            : studyTotals[SITE_NAMES[label]]?.count || null}
-        </div>
+        <div className="BarGraphTooltip_values">{countsTotal}</div>
       </div>
       {!displayLeft ? <div className="arrow-right" /> : null}
     </div>


### PR DESCRIPTION
closes #691 
This pr fixes some tooltip styling and data display 🐛

One of the challenges I found is the length of the site's name. I increased the width by 50px, otherwise the name stacks vertically and it looks weird. Going to wait for client feedback.

<img width="151" alt="Screenshot 2024-03-20 at 1 31 10 PM" src="https://github.com/dptools/dpdash/assets/19805355/60cf4466-945f-4cbf-b761-157d65836cb2">
<img width="188" alt="Screenshot 2024-03-20 at 1 31 17 PM" src="https://github.com/dptools/dpdash/assets/19805355/1420301c-04c8-4e04-b474-2e063023391e">
