### PR TITLE
Bar size

### DIFF
--- a/views/components/BarGraph/index.jsx
+++ b/views/components/BarGraph/index.jsx
@@ -51,7 +51,7 @@ const BarGraph = ({
       }}
     >
       <ResponsiveContainer
-        width="100%"
+        width="98%"
         height={500}
         ref={(element) => {
           if (element) {
@@ -63,7 +63,6 @@ const BarGraph = ({
       >
         <BarChart
           data={sanitizeSiteData(siteData)}
-          barSize={50}
           margin={{ top: 50 }}
           onMouseMove={(data) => {
             if (data.isTooltipActive) {
@@ -72,7 +71,6 @@ const BarGraph = ({
               handleTooltipPosition({ chartWidth: xAxisWidth, xCoordinate })
             }
           }}
-          barCategoryGap={40}
         >
           <Legend
             margin={{ bottom: 10 }}
@@ -89,6 +87,7 @@ const BarGraph = ({
             dataKey={xAxisKey}
             height={100}
             padding={{ left: 12.5, right: 12.5 }}
+            fontSize={5}
             id="chartWidth"
             interval={0}
             tick={useSiteName ? undefined : <BarGraphXAxisLabel />}
@@ -117,7 +116,6 @@ const BarGraph = ({
                 id={label.name}
                 stackId="a"
                 fill={label.color}
-                barSize={50}
               >
                 <LabelList
                   label={{ fontSize: fontSize[14] }}

--- a/views/components/BarGraph/index.jsx
+++ b/views/components/BarGraph/index.jsx
@@ -117,7 +117,7 @@ const BarGraph = ({
                 id={label.name}
                 stackId="a"
                 fill={label.color}
-                barSize={90}
+                barSize={50}
               >
                 <LabelList
                   label={{ fontSize: fontSize[14] }}

--- a/views/components/BarGraph/index.jsx
+++ b/views/components/BarGraph/index.jsx
@@ -51,7 +51,7 @@ const BarGraph = ({
       }}
     >
       <ResponsiveContainer
-        width="98%"
+        width="100%"
         height={500}
         ref={(element) => {
           if (element) {
@@ -87,7 +87,6 @@ const BarGraph = ({
             dataKey={xAxisKey}
             height={100}
             padding={{ left: 12.5, right: 12.5 }}
-            fontSize={5}
             id="chartWidth"
             interval={0}
             tick={useSiteName ? undefined : <BarGraphXAxisLabel />}


### PR DESCRIPTION
closes #712 

This pr makes it so that the bar size and gap are smaller. The ticket calls for maximum bar size property, but that property affects only the height on a vertical bar graph and the width is on a horizontal bar graph. Making the width smaller also closes the gap.

https://recharts.org/en-US/api/Bar#:~:text=of%20bar%20groups.-,maxBarSize,-Number

<img width="671" alt="Screenshot 2024-03-27 at 2 23 26 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/74d6e001-40cb-49f8-9fb0-6b2d26f5d4d2">

<img width="1136" alt="Screenshot 2024-03-27 at 2 17 17 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/93ef89e6-d95e-4561-93ec-200e9732b4b0">

