### PR TITLE
Investigate bar charts that don't reach 100%

### DIFF
--- a/server/data_processors/BarChartDataProcessor/BarChartDataProcessor.test.js
+++ b/server/data_processors/BarChartDataProcessor/BarChartDataProcessor.test.js
@@ -91,8 +91,8 @@ describe(BarChartDataProcessor, () => {
           siteCode: 'Totals',
           name: 'Totals',
           percentages: {
-            Bar: 16,
-            Foo: 83,
+            Bar: 16.666666666666664,
+            Foo: 83.33333333333334,
             'N/A': 0,
           },
           targets: {

--- a/server/data_processors/BarChartDataProcessor/index.js
+++ b/server/data_processors/BarChartDataProcessor/index.js
@@ -2,11 +2,10 @@ import { EMPTY_VALUE, N_A, TOTALS_STUDY, TOTAL_LABEL } from '../../constants'
 import { SITE_NAMES } from '../../utils/siteNames'
 
 const studyCountsToPercentage = (studyCount, targetTotal) => {
-  if (!targetTotal || Number.isNaN(+studyCount) || Number.isNaN(+targetTotal)) {
+  if (!targetTotal || Number.isNaN(+studyCount) || Number.isNaN(+targetTotal))
     return 0
-  }
 
-  return Math.floor((+studyCount / +targetTotal) * 100)
+  return (+studyCount / +targetTotal) * 100
 }
 
 const calculateTotalsTargetValue = (currentTargetCount, nextTargetCount) =>

--- a/server/services/BarChartService/BarChartService.test.js
+++ b/server/services/BarChartService/BarChartService.test.js
@@ -102,8 +102,8 @@ describe(BarChartService, () => {
               siteCode: 'Totals',
               name: 'Totals',
               percentages: {
-                Foo: 14,
-                'N/A': 85,
+                Foo: 14.285714285714285,
+                'N/A': 85.71428571428571,
               },
               targets: {
                 Bar: 3,

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -167,9 +167,9 @@ export const chartsDataSuccessResponse = (overrides = {}) => ({
       siteCode: 'Totals',
       name: 'Totals',
       percentages: {
-        Bar: 14,
-        Foo: 71,
-        'N/A': 14,
+        Bar: 14.285714285714285,
+        Foo: 71.42857142857143,
+        'N/A': 14.285714285714285,
       },
       targets: {
         Bar: 5,
@@ -429,8 +429,8 @@ export const chartsDataInitialResponse = (overrides = {}) => ({
       siteCode: 'Totals',
       name: 'Totals',
       percentages: {
-        Foo: 14,
-        'N/A': 85,
+        Foo: 14.285714285714285,
+        'N/A': 85.71428571428571,
       },
       targets: {
         Bar: 3,
@@ -658,8 +658,8 @@ export const chartsDataFilterResponse = (overrides = {}) => ({
       siteCode: 'Totals',
       name: 'Totals',
       percentages: {
-        Foo: 7,
-        'N/A': 92,
+        Foo: 7.142857142857142,
+        'N/A': 92.85714285714286,
       },
       targets: {
         Bar: 2,

--- a/views/components/BarGraph/index.jsx
+++ b/views/components/BarGraph/index.jsx
@@ -92,12 +92,7 @@ const BarGraph = ({
             interval={0}
             tick={useSiteName ? undefined : <BarGraphXAxisLabel />}
           />
-          <YAxis
-            width={80}
-            domain={([dataMin, dataMax]) => [0, 100]}
-            type="number"
-            allowDataOverflow={false}
-          >
+          <YAxis width={80} domain={([dataMin, dataMax]) => [0, 100]}>
             <Label value="Percent" angle={-90} />
           </YAxis>
           <Tooltip

--- a/views/components/BarGraph/index.jsx
+++ b/views/components/BarGraph/index.jsx
@@ -71,6 +71,7 @@ const BarGraph = ({
               handleTooltipPosition({ chartWidth: xAxisWidth, xCoordinate })
             }
           }}
+          maxBarSize={100}
         >
           <Legend
             margin={{ bottom: 10 }}
@@ -91,7 +92,12 @@ const BarGraph = ({
             interval={0}
             tick={useSiteName ? undefined : <BarGraphXAxisLabel />}
           />
-          <YAxis width={80} domain={[0, 100]}>
+          <YAxis
+            width={80}
+            domain={([dataMin, dataMax]) => [0, 100]}
+            type="number"
+            allowDataOverflow={false}
+          >
             <Label value="Percent" angle={-90} />
           </YAxis>
           <Tooltip


### PR DESCRIPTION
closes #713 
This pr makes it so that bars in the bar graph do not exceed 100. 
It removes the rounding of percentages on the server and now we set a strict domain to the y axis of the bar graph.

<img width="1119" alt="Screenshot 2024-03-29 at 10 37 11 AM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/ea05454f-b2f1-472d-9c3c-4f1a86291c05">

