### PR TITLE
Weird name display in configurations table

### DIFF
--- a/server/controllers/configurationsController/index.js
+++ b/server/controllers/configurationsController/index.js
@@ -85,7 +85,6 @@ const ConfigurationsController = {
 
       return res.status(200).json({ data: Array.from(dataSet) })
     } catch (error) {
-      console.log(error)
       return res.status(400).json({ error: error.message })
     }
   },

--- a/server/models/ConfigModel/index.js
+++ b/server/models/ConfigModel/index.js
@@ -51,39 +51,4 @@ const ConfigModel = {
   }),
 }
 
-const loadAllConfigurationsMongoQuery = (userId) => {
-  const users = 'users'
-  const owner = 'owner'
-  const uid = 'uid'
-  const configOwner = 'ownerUser'
-
-  return [
-    {
-      $match: {
-        $or: [{ readers: userId }, { public: true }],
-      },
-    },
-    {
-      $lookup: {
-        from: users,
-        localField: uid,
-        foreignField: owner,
-        as: configOwner,
-      },
-    },
-    {
-      $project: {
-        _id: 1,
-        name: 1,
-        type: 1,
-        created: 1,
-        owner: 1,
-        readers: 1,
-        config: 1,
-        owner_display_name: '$ownerUser.display_name',
-      },
-    },
-  ]
-}
-
 export default ConfigModel

--- a/server/models/ConfigModel/index.js
+++ b/server/models/ConfigModel/index.js
@@ -31,8 +31,8 @@ const ConfigModel = {
   index: async (db, userId) =>
     await db
       .collection(collections.configs)
-      .aggregate(loadAllConfigurationsMongoQuery(userId))
-      .toArray(),
+      .find({ $or: [{ readers: userId }, { public: true }] })
+      .stream(),
   create: async (db, configAttributes) => {
     const { insertedId } = await db
       .collection(collections.configs)

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -152,7 +152,7 @@ export const createConfiguration = (overrides = {}) => ({
   config: {},
   type: 'matrix',
   created: 'Mon, 12 June 2023',
-  readers: [],
+  readers: ['owl'],
   ...overrides,
 })
 


### PR DESCRIPTION
The created by column in the Configurations table displays many names and duplicates. This is because the join we were using in the query returns an array of values and not a single result.

In this pr we stream the data, and programmatically  lookup the user that owns the configuration, we have to do this because [document db does not support subqueries after a join operation](https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.lookup). We were using a subquery to reduce that array of results into one object. 

To speed things along, the users are cached.

<img width="1440" alt="Screenshot 2024-04-01 at 12 30 31 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/1adb9bea-2070-43fe-a77c-0bc9e2d19f55">

