### PR TITLE
Add study page table

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,26 +4,26 @@
     "plugin:react/recommended",
     "prettier",
     "universe/web",
-    "universe/node"
+    "universe/node",
   ],
   "parser": "@babel/eslint-parser",
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
   },
   "parserOptions": {
     "requireConfigFile": false,
     "babelOptions": {
-      "presets": ["@babel/preset-react"]
+      "presets": ["@babel/preset-react"],
     },
     "ecmaFeatures": {
-        "jsx": true
+      "jsx": true,
     },
     "ecmaVersion": 15,
     "sourceType": "module",
     "parserOptions": {
-      "project": "./tsconfig.json"
-    }
+      "project": "./tsconfig.json",
+    },
   },
   "plugins": [
     "react",
@@ -32,17 +32,20 @@
     "no-only-tests",
     "sort-keys-fix",
     "prettier",
-    "promise"
+    "promise",
   ],
   "rules": {
     "react/prop-types": "off",
-    "no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+    "no-unused-vars": [
+      "error",
+      { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" },
+    ],
     "import/order": [
       "error",
       {
         "alphabetize": {
           "caseInsensitive": true,
-          "order": "asc"
+          "order": "asc",
         },
         "groups": ["builtin", "external", "internal"],
         "newlines-between": "always",
@@ -50,13 +53,13 @@
           {
             "group": "external",
             "pattern": "react",
-            "position": "before"
-          }
+            "position": "before",
+          },
         ],
-        "pathGroupsExcludedImportTypes": ["react"]
-      }
+        "pathGroupsExcludedImportTypes": ["react"],
+      },
     ],
     "no-only-tests/no-only-tests": "error",
-    "react/react-in-jsx-scope": "off"
-  }
+    "react/react-in-jsx-scope": "off",
+  },
 }

--- a/server/app.js
+++ b/server/app.js
@@ -27,6 +27,7 @@ import indexRouter from './routes/index'
 import participantsRouter from './routes/participants'
 import siteMetadata from './routes/siteMetadata'
 import usersRouter from './routes/users'
+import userStudiesRouter from './routes/userStudies'
 import { verifyHash } from './utils/crypto/hash'
 
 const localStrategy = Strategy
@@ -151,8 +152,8 @@ passport.deserializeUser(async function (user, done) {
   done(null, user)
 })
 
-app.use('/', assessmentData)
 app.use('/', adminRouter)
+app.use('/', assessmentData)
 app.use('/', authRouter)
 app.use('/', chartsRouter)
 app.use('/', configurationsRouter)
@@ -161,6 +162,7 @@ app.use('/', indexRouter)
 app.use('/', participantsRouter)
 app.use('/', siteMetadata)
 app.use('/', usersRouter)
+app.use('/', userStudiesRouter)
 app.use('./img', express.static(path.join(__dirname, '../public/img')))
 
 app.get('/*', async (req, res) => {

--- a/server/controllers/api/assessmentDayDataController/assessmentDayDataController.test.js
+++ b/server/controllers/api/assessmentDayDataController/assessmentDayDataController.test.js
@@ -230,6 +230,7 @@ describe('assessmentDayDataController', () => {
               projection: {
                 _id: 0,
                 'participants.synced': 0,
+                updatedAt: 0,
               },
             }
           )

--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -81,7 +81,7 @@ const AssessmentDayDataController = {
           appDb,
           { study },
           {
-            $set: {
+            setAttributes: {
               study,
               participants: [
                 {
@@ -105,7 +105,7 @@ const AssessmentDayDataController = {
             appDb,
             { participants: { $elemMatch: { participant } } },
             {
-              $set: {
+              setAttributes: {
                 'participants.$.daysInStudy': maxDayInDayData,
                 'participants.$.synced': new Date(),
               },
@@ -116,7 +116,7 @@ const AssessmentDayDataController = {
             appDb,
             { study },
             {
-              $addToSet: {
+              addToSetAttributes: {
                 participants: {
                   Active,
                   Consent: parsedConsent,

--- a/server/controllers/api/siteMetadataController/index.js
+++ b/server/controllers/api/siteMetadataController/index.js
@@ -10,16 +10,20 @@ const SiteMetadataController = {
 
       participants.forEach((participant, i) => {
         participants[i].Consent = new Date(participant.Consent)
-        if (participants[i]?.synced)
-          participants[i].synced = new Date(participant.synced)
       })
-
       const studyMetadata = await SiteMetadataModel.findOne(appDb, { study })
+
       if (!studyMetadata) {
         await SiteMetadataModel.upsert(
           appDb,
           { study },
-          { $set: { ...metadata, participants } }
+          {
+            setAttributes: {
+              ...metadata,
+              participants,
+              createdAt: new Date(),
+            },
+          }
         )
       } else {
         Promise.all(
@@ -36,7 +40,7 @@ const SiteMetadataController = {
               await SiteMetadataModel.upsert(
                 appDb,
                 { study },
-                { $addToSet: { participants: participant } }
+                { addToSetAttributes: { participants: participant } }
               )
             } else {
               const updatedAttributes = Object.keys(participant).reduce(
@@ -54,7 +58,7 @@ const SiteMetadataController = {
                     $elemMatch: { participant: participant.participant },
                   },
                 },
-                { $set: updatedAttributes }
+                { setAttributes: updatedAttributes }
               )
             }
           })

--- a/server/controllers/api/siteMetadataController/siteMetadataController.test.js
+++ b/server/controllers/api/siteMetadataController/siteMetadataController.test.js
@@ -227,6 +227,7 @@ describe('siteMetadataController', () => {
             role: 'metadata',
             study: 'site',
             extension: '.csv',
+            updatedAt: new Date(),
           },
           participants: [
             {
@@ -234,12 +235,14 @@ describe('siteMetadataController', () => {
               Active: 1,
               Consent: '2022-06-02',
               study: 'YA',
+              daysInStudy: 55,
             },
             {
               participant: 'YA2',
               Active: 1,
               Consent: '2022-06-02',
               study: 'YA',
+              daysInStudy: 105,
             },
           ],
         })

--- a/server/controllers/studiesController/index.js
+++ b/server/controllers/studiesController/index.js
@@ -1,6 +1,6 @@
 import StudiesModel from '../../models/StudiesModel'
 
-const StudiesController = {
+const studiesController = {
   index: async (req, res) => {
     try {
       const { appDb } = req.app.locals
@@ -13,4 +13,4 @@ const StudiesController = {
   },
 }
 
-export default StudiesController
+export default studiesController

--- a/server/controllers/studiesController/studiesController.test.js
+++ b/server/controllers/studiesController/studiesController.test.js
@@ -1,8 +1,8 @@
-import StudiesController from '.'
+import studiesController from '.'
 import { createRequest, createResponse } from '../../../test/fixtures'
 
-describe('StudiesController', () => {
-  describe(StudiesController.index, () => {
+describe('studiesController', () => {
+  describe(studiesController.index, () => {
     describe('When successful', () => {
       it('returns a status of 200 with a list of distinct studies', async () => {
         const request = createRequest()
@@ -11,7 +11,7 @@ describe('StudiesController', () => {
 
         request.app.locals.appDb.distinct.mockResolvedValueOnce(listOfStudies)
 
-        await StudiesController.index(request, response)
+        await studiesController.index(request, response)
 
         expect(response.status).toHaveBeenCalledWith(200)
         expect(response.json).toHaveBeenCalledWith({
@@ -28,7 +28,7 @@ describe('StudiesController', () => {
           new Error('some error')
         )
 
-        await StudiesController.index(request, response)
+        await studiesController.index(request, response)
 
         expect(response.status).toHaveBeenCalledWith(400)
         expect(response.json).toHaveBeenCalledWith({

--- a/server/controllers/userStudiesController/index.js
+++ b/server/controllers/userStudiesController/index.js
@@ -1,0 +1,31 @@
+import UserModel from '../../models/UserModel'
+import UserStudiesModel from '../../models/UserStudiesModel'
+
+const userStudiesController = {
+  index: async (req, res) => {
+    try {
+      const { appDb } = req.app.locals
+      const isSortRequested = Object.hasOwn(req.query, 'sort')
+      const parsedSortParams =
+        isSortRequested && Object.keys(req.query.sort).length
+          ? req.query.sort
+          : { sortBy: 'study', sortDirection: 'ASC' }
+      const userAccess = await UserModel.findOne(
+        appDb,
+        { uid: req.user.uid },
+        { access: 1 }
+      )
+      const userStudies = await UserStudiesModel.all(
+        appDb,
+        userAccess.access,
+        parsedSortParams
+      )
+
+      return res.status(200).json({ data: userStudies })
+    } catch (error) {
+      return res.status(400).json({ message: error.message })
+    }
+  },
+}
+
+export default userStudiesController

--- a/server/controllers/userStudiesController/userStudiesController.test.js
+++ b/server/controllers/userStudiesController/userStudiesController.test.js
@@ -1,0 +1,126 @@
+import userStudiesController from '.'
+import {
+  createResponse,
+  createRequestWithUser,
+  createUser,
+  createStudyTableRowData,
+} from '../../../test/fixtures'
+import { createStudies } from '../../../test/testUtils'
+import { collections } from '../../utils/mongoCollections'
+
+describe('userStudiesController', () => {
+  describe(userStudiesController.index, () => {
+    describe('When successful', () => {
+      let appDb
+      let user
+
+      beforeAll(async () => {
+        user = createUser({
+          uid: 'owl',
+          preferences: {},
+          access: ['YA', 'LA', 'MA'],
+        })
+
+        appDb = await global.MONGO_INSTANCE.db('studies')
+
+        await appDb.collection(collections.users).insertOne(user)
+        await appDb.collection(collections.metadata).insertMany(createStudies())
+      })
+      afterAll(async () => {
+        await appDb.dropDatabase()
+      })
+
+      it('returns a list of studies with the column properties to be displayed', async () => {
+        const response = createResponse()
+        const request = createRequestWithUser(
+          {
+            query: { sort: {} },
+            app: { locals: { appDb } },
+          },
+          user
+        )
+        const data = [
+          createStudyTableRowData({
+            daysInStudy: 655,
+            numOfParticipants: 2,
+            study: 'LA',
+            updatedAt: new Date('01-05-2024'),
+          }),
+          createStudyTableRowData({
+            daysInStudy: 1005,
+            numOfParticipants: 2,
+            study: 'MA',
+            updatedAt: new Date('01-05-2024'),
+          }),
+          createStudyTableRowData({
+            daysInStudy: 105,
+            numOfParticipants: 2,
+            study: 'YA',
+            updatedAt: new Date('01-05-2024'),
+          }),
+        ]
+        await userStudiesController.index(request, response)
+
+        expect(response.status).toHaveBeenCalledWith(200)
+        expect(response.json).toHaveBeenCalledWith({
+          data,
+        })
+      })
+
+      it('returns a list using default sort properties if sort property is missing', async () => {
+        const response = createResponse()
+        const request = createRequestWithUser(
+          {
+            query: {},
+            app: { locals: { appDb } },
+          },
+          user
+        )
+        const data = [
+          createStudyTableRowData({
+            daysInStudy: 655,
+            numOfParticipants: 2,
+            study: 'LA',
+            updatedAt: new Date('01-05-2024'),
+          }),
+          createStudyTableRowData({
+            daysInStudy: 1005,
+            numOfParticipants: 2,
+            study: 'MA',
+            updatedAt: new Date('01-05-2024'),
+          }),
+          createStudyTableRowData({
+            daysInStudy: 105,
+            numOfParticipants: 2,
+            study: 'YA',
+            updatedAt: new Date('01-05-2024'),
+          }),
+        ]
+
+        await userStudiesController.index(request, response)
+
+        expect(response.status).toHaveBeenCalledWith(200)
+        expect(response.json).toHaveBeenCalledWith({
+          data,
+        })
+      })
+    })
+    describe('When unsuccessful', () => {
+      it('returns a status of 400 and an error', async () => {
+        const request = createRequestWithUser({ query: { sort: {} } })
+        const response = createResponse()
+
+        request.app.locals.appDb.findOne.mockRejectedValueOnce(
+          new Error('some error')
+        )
+
+        await userStudiesController.index(request, response)
+
+        expect(response.status).toHaveBeenCalledWith(400)
+        expect(response.json).toHaveBeenCalledWith({
+          message: 'some error',
+        })
+      })
+    })
+  })
+})

--- a/server/models/SiteMetadataModel/index.js
+++ b/server/models/SiteMetadataModel/index.js
@@ -1,15 +1,23 @@
 import { collections } from '../../utils/mongoCollections'
 
+const queryOptions = {
+  upsert: true,
+  returnDocument: 'after',
+}
 const SiteMetadataModel = {
   findOne: async (db, query) =>
     await db.collection(collections.metadata).findOne(query),
-  upsert: async (db, query, metadataAttributes) =>
-    await db
-      .collection(collections.metadata)
-      .findOneAndUpdate(query, metadataAttributes, {
-        upsert: true,
-        returnDocument: 'after',
-      }),
+  upsert: async (db, query, { setAttributes, addToSetAttributes }) =>
+    await db.collection(collections.metadata).findOneAndUpdate(
+      query,
+      {
+        $set: { ...(setAttributes || {}), updatedAt: new Date() },
+        $addToSet: Object.keys(addToSetAttributes || {}).length
+          ? { ...addToSetAttributes, createdAt: new Date() }
+          : {},
+      },
+      queryOptions
+    ),
 }
 
 export default SiteMetadataModel

--- a/server/models/UserStudiesModel/index.js
+++ b/server/models/UserStudiesModel/index.js
@@ -1,0 +1,37 @@
+import { ASC, STUDIES_TO_OMIT } from '../../constants'
+import { collections } from '../../utils/mongoCollections'
+
+const UserStudiesModel = {
+  all: async (db, studiesList, sortDirective) =>
+    await db
+      .collection(collections.metadata)
+      .aggregate(userStudiesQuery(studiesList, sortDirective))
+      .toArray(),
+}
+
+const userStudiesQuery = (studiesList, sortDirective) => {
+  const sortDirection = sortDirective.sortDirection === ASC ? 1 : -1
+  const sort = { [sortDirective.sortBy]: sortDirection }
+
+  return [
+    { $match: { study: { $in: studiesList, $nin: STUDIES_TO_OMIT } } },
+    {
+      $project: {
+        _id: 0,
+        study: 1,
+        numOfParticipants: {
+          $cond: {
+            if: { $isArray: '$participants' },
+            then: { $size: '$participants' },
+            else: 0,
+          },
+        },
+        daysInStudy: { $max: '$participants.daysInStudy' },
+        updatedAt: 1,
+      },
+    },
+    { $sort: sort },
+  ]
+}
+
+export default UserStudiesModel

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import * as yup from 'yup'
 
 import AdminUsersController from '../controllers/adminController'
-import StudiesController from '../controllers/studiesController'
+import studiesController from '../controllers/studiesController'
 import validateRequest, { baseSchema } from '../middleware/validateRequest'
 import ensureAdmin from '../utils/passport/ensure-admin'
 import { v1Routes } from '../utils/routes'
@@ -40,6 +40,6 @@ router
 
 router
   .route(v1Routes.admin.studies.index)
-  .get(ensureAdmin, StudiesController.index)
+  .get(ensureAdmin, studiesController.index)
 
 export default router

--- a/server/routes/userStudies.js
+++ b/server/routes/userStudies.js
@@ -1,0 +1,13 @@
+import { Router } from 'express'
+
+import userStudiesController from '../controllers/userStudiesController'
+import ensureAuthenticated from '../utils/passport/ensure-authenticated'
+import { v1Routes } from '../utils/routes'
+
+const router = Router()
+
+router
+  .route(v1Routes.userStudies.index)
+  .get(ensureAuthenticated, userStudiesController.index)
+
+export default router

--- a/server/utils/routes.js
+++ b/server/utils/routes.js
@@ -56,6 +56,9 @@ export const v1Routes = {
   siteMetadata: {
     index: `${v1Root}/import/data/metadata`,
   },
+  userStudies: {
+    index: `${v1Root}/user-studies`,
+  },
   users: {
     index: `${v1Root}/users`,
     show: userRoot,

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -384,3 +384,27 @@ export const createAsessmentVariable = (overrides = {}) => ({
   assessment: '',
   ...overrides,
 })
+
+export const createStudy = (overrides = {}) => ({
+  study: '',
+  updatedAt: '',
+  participants: [],
+  ...overrides,
+})
+
+export const createStudyTableRowData = (overrides = {}) => ({
+  daysInStudy: 0,
+  numOfParticipants: 0,
+  study: '',
+  updatedAt: '',
+  ...overrides,
+})
+
+export const createSiteParticipant = (overrides = {}) => ({
+  participant: ' ',
+  Active: 1,
+  Consent: '',
+  study: '',
+  daysInStudy: 0,
+  ...overrides,
+})

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,4 +1,8 @@
-import { createAssessmentDayData } from './fixtures'
+import {
+  createAssessmentDayData,
+  createSiteParticipant,
+  createStudy,
+} from './fixtures'
 import {
   INCLUSION_EXCLUSION_CRITERIA_FORM,
   SOCIODEMOGRAPHICS_FORM,
@@ -850,3 +854,66 @@ export const chartsDataFilterResponse = (overrides = {}) => ({
   lastModified: '',
   ...overrides,
 })
+
+export const createStudies = () => [
+  createStudy({
+    study: 'YA',
+    updatedAt: new Date('01-05-2024'),
+    participants: [
+      createSiteParticipant({
+        participant: 'YA1',
+        Active: 1,
+        Consent: '2022-06-02',
+        study: 'YA',
+        daysInStudy: 55,
+      }),
+      createSiteParticipant({
+        participant: 'YA2',
+        Active: 1,
+        Consent: '2022-06-02',
+        study: 'YA',
+        daysInStudy: 105,
+      }),
+    ],
+  }),
+  createStudy({
+    study: 'MA',
+    updatedAt: new Date('01-05-2024'),
+    participants: [
+      createSiteParticipant({
+        participant: 'MA1',
+        Active: 1,
+        Consent: '2022-06-02',
+        study: 'MA',
+        daysInStudy: 55,
+      }),
+      createSiteParticipant({
+        participant: 'MA2',
+        Active: 1,
+        Consent: '2022-06-02',
+        study: 'MA',
+        daysInStudy: 1005,
+      }),
+    ],
+  }),
+  createStudy({
+    study: 'LA',
+    updatedAt: new Date('01-05-2024'),
+    participants: [
+      createSiteParticipant({
+        participant: 'LA1',
+        Active: 1,
+        Consent: '2022-06-02',
+        study: 'LA',
+        daysInStudy: 655,
+      }),
+      createSiteParticipant({
+        participant: 'LA2',
+        Active: 1,
+        Consent: '2022-06-02',
+        study: 'LA',
+        daysInStudy: 5,
+      }),
+    ],
+  }),
+]

--- a/views/api/index.js
+++ b/views/api/index.js
@@ -5,6 +5,7 @@ import dashboard from './dashboard'
 import participants from './participants'
 import userConfigurations from './userConfigurations'
 import users from './users'
+import userStudies from './userStudies'
 
 const api = {
   admin,
@@ -12,6 +13,7 @@ const api = {
   charts,
   dashboard,
   participants,
+  userStudies,
   userConfigurations,
   users,
 }

--- a/views/api/userStudies/index.js
+++ b/views/api/userStudies/index.js
@@ -1,0 +1,9 @@
+import { apiRoutes } from '../../routes/routes'
+import http from '../http'
+
+const userStudies = {
+  loadAll: async (queryParams) =>
+    http.get(apiRoutes.userStudies.index, queryParams),
+}
+
+export default userStudies

--- a/views/components/StatusChip/index.jsx
+++ b/views/components/StatusChip/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { Chip } from '@mui/material'
+
+import { borderRadius, fontSize } from '../../../constants'
+
+const StatusChip = ({ isActive }) => {
+  return (
+    <Chip
+      sx={{
+        backgroundColor: isActive ? 'primary.light' : 'grey.A300',
+        color: isActive ? 'text.secondary' : 'text.primary',
+        fontSize: fontSize[14],
+        fontWeight: 500,
+        p: isActive ? '0 19px 0 15px' : '0 10px',
+        borderRadius: borderRadius[24],
+      }}
+      label={isActive ? 'Active' : 'Inactive'}
+    />
+  )
+}
+
+export default StatusChip

--- a/views/pages/StudiesPage/StudiesPage.test.jsx
+++ b/views/pages/StudiesPage/StudiesPage.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { render, screen, waitFor } from '@testing-library/react'
+
+import StudiesPage from '.'
+import { createStudyTableRowData } from '../../../test/fixtures'
+import api from '../../api'
+
+describe(StudiesPage, () => {
+  const renderPage = () => render(<StudiesPage />)
+  beforeEach(() => {
+    jest.spyOn(api.userStudies, 'loadAll').mockResolvedValueOnce([
+      createStudyTableRowData({
+        daysInStudy: 655,
+        numOfParticipants: 2,
+        study: 'LA',
+        updatedAt: '2024-01-05T06:00:00.000Z',
+      }),
+    ])
+  })
+  it('renders the studies page header', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Studies')).toBeInTheDocument()
+    })
+  })
+
+  it('renders the studies page table', async () => {
+    renderPage()
+
+    const table = screen.getByRole('table')
+
+    await waitFor(() => {
+      expect(table).toBeInTheDocument()
+    })
+  })
+})

--- a/views/pages/StudiesPage/index.jsx
+++ b/views/pages/StudiesPage/index.jsx
@@ -1,13 +1,48 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { Box } from '@mui/material'
 
+import { SORT_DIRECTION } from '../../../constants'
+import api from '../../api'
 import PageHeader from '../../components/PageHeader'
+import useTableSort from '../../hooks/useTableSort'
+import StudiesTable from '../../tables/StudiesTable'
+
+const siteName = 'siteName'
+const study = 'study'
 
 const StudiesPage = () => {
+  const [studies, setStudies] = useState([])
+  const { onSort, sortDirection, sortBy } = useTableSort(study)
+  const loadStudies = async () => {
+    const sortParams = {
+      ...(sortBy ? { sortBy: sortBy === siteName ? study : sortBy } : {}),
+      ...(sortDirection ? { sortDirection } : {}),
+    }
+    const data = await api.userStudies.loadAll({ sort: sortParams })
+
+    setStudies(data)
+  }
+  const handleRequestSort = (_event, property) => {
+    const isAsc = sortDirection === SORT_DIRECTION.ASC
+
+    return onSort(property, isAsc ? SORT_DIRECTION.DESC : SORT_DIRECTION.ASC)
+  }
+
+  useEffect(() => {
+    loadStudies()
+  }, [sortBy, sortDirection])
+
   return (
     <Box sx={{ p: '20px' }}>
       <PageHeader title="Studies" />
+      <StudiesTable
+        studies={studies}
+        onSort={handleRequestSort}
+        sortDirection={sortDirection}
+        sortProperty={sortBy}
+        sortable
+      />
     </Box>
   )
 }

--- a/views/routes/routes.js
+++ b/views/routes/routes.js
@@ -41,13 +41,6 @@ export const routes = {
 }
 
 export const apiRoutes = {
-  auth: {
-    login: `${apiPath}/login`,
-    logout: `${apiPath}/logout`,
-    me: `${apiPath}/me`,
-    resetPassword: `${apiPath}/resetpw`,
-    signup: `${apiPath}/signup`,
-  },
   admin: {
     users: {
       show: (uid) => `${apiPath}/admin/users/${uid}`,
@@ -55,6 +48,17 @@ export const apiRoutes = {
     studies: {
       all: `${apiPath}/admin/search/studies`,
     },
+  },
+  auth: {
+    login: `${apiPath}/login`,
+    logout: `${apiPath}/logout`,
+    me: `${apiPath}/me`,
+    resetPassword: `${apiPath}/resetpw`,
+    signup: `${apiPath}/signup`,
+  },
+  chart: {
+    show: (chart_id) => `${apiPath}/charts/${chart_id}`,
+    index: `${apiPath}/charts`,
   },
   chartData: {
     show: (chartId) => `${apiPath}/charts/${chartId}/data`,
@@ -76,24 +80,23 @@ export const apiRoutes = {
     show: (study = ':study', subject = ':subject') =>
       `${apiPath}/dashboards/${study}/${subject}`,
   },
+  duplicateChart: {
+    show: `${apiPath}/charts/duplicate`,
+  },
   participants: {
     index: `${apiPath}/participants`,
   },
+  preferences: (uid) => `${apiPath}/users/${uid}/preferences`,
+  shareChart: {
+    show: (chart_id) => `${apiPath}/charts/${chart_id}/share`,
+  },
+  userStudies: {
+    index: `${apiPath}/user-studies`,
+  },
+  subjects: (studies) => `${apiPath}/subjects?q=${JSON.stringify(studies)}`,
+  subject: `${apiPath}/subjects`,
   users: {
     index: `${apiPath}/users`,
     show: (uid) => `${apiPath}/users/${uid}`,
   },
-  chart: {
-    show: (chart_id) => `${apiPath}/charts/${chart_id}`,
-    index: `${apiPath}/charts`,
-  },
-  shareChart: {
-    show: (chart_id) => `${apiPath}/charts/${chart_id}/share`,
-  },
-  duplicateChart: {
-    show: `${apiPath}/charts/duplicate`,
-  },
-  subjects: (studies) => `${apiPath}/subjects?q=${JSON.stringify(studies)}`,
-  preferences: (uid) => `${apiPath}/users/${uid}/preferences`,
-  subject: `${apiPath}/subjects`,
 }

--- a/views/tables/ParticipantsTable/index.jsx
+++ b/views/tables/ParticipantsTable/index.jsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
 import { Star, StarBorder } from '@mui/icons-material'
-import { Checkbox, Chip, Typography, Tooltip } from '@mui/material'
+import { Checkbox, Typography, Tooltip } from '@mui/material'
 import dayjs from 'dayjs'
 import isToday from 'dayjs/plugin/isToday'
 import isYesterday from 'dayjs/plugin/isYesterday'
 import { Link } from 'react-router-dom'
 
-import { SORT_DIRECTION, fontSize, borderRadius } from '../../../constants'
+import { SORT_DIRECTION } from '../../../constants'
 import { SITE_NAMES } from '../../../server/utils/siteNames'
+import StatusChip from '../../components/StatusChip'
 import { routes } from '../../routes/routes'
 import Table from '../Table'
 
@@ -107,19 +108,7 @@ const ParticipantsTable = (props) => {
       case 'Active': {
         const isActive = participant[property] === 1
 
-        return (
-          <Chip
-            sx={{
-              backgroundColor: isActive ? 'primary.light' : 'grey.A300',
-              color: isActive ? 'text.secondary' : 'text.primary',
-              fontSize: fontSize[14],
-              fontWeight: 500,
-              p: isActive ? '0 19px 0 15px' : '0 10px',
-              borderRadius: borderRadius[24],
-            }}
-            label={isActive ? 'Active' : 'Inactive'}
-          />
-        )
+        return <StatusChip isActive={isActive} />
       }
       case 'star':
         return (

--- a/views/tables/StudiesTable/StudiesTable.test.jsx
+++ b/views/tables/StudiesTable/StudiesTable.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+
+import { render, screen, within } from '@testing-library/react'
+
+import StudiesTable from '.'
+import { SITE_NAMES } from '../../../server/utils/siteNames'
+import { createStudyTableRowData } from '../../../test/fixtures'
+
+describe(StudiesTable, () => {
+  const studies = [
+    createStudyTableRowData({
+      daysInStudy: 655,
+      numOfParticipants: 2,
+      study: 'LA',
+      updatedAt: '2024-01-05T06:00:00.000Z',
+    }),
+    createStudyTableRowData({
+      daysInStudy: 1005,
+      numOfParticipants: 2,
+      study: 'MA',
+      updatedAt: '2024-01-05T06:00:00.000Z',
+    }),
+    createStudyTableRowData({
+      daysInStudy: 105,
+      numOfParticipants: 2,
+      study: 'YA',
+      updatedAt: '2024-01-05T06:00:00.000Z',
+    }),
+  ]
+  const defaultProps = {
+    studies,
+    onDelete: () => {},
+    onDuplicate: () => {},
+    onShare: () => {},
+    onFavorite: () => {},
+  }
+  const tableRow = (rowNum) => screen.getByTestId(`row-${rowNum}`)
+  const renderTable = (props = defaultProps) =>
+    render(<StudiesTable {...props} />)
+
+  it('renders the studies table', () => {
+    renderTable()
+
+    expect(within(tableRow(0)).getByText(studies[0].study)).toBeInTheDocument()
+    expect(
+      within(tableRow(0)).getByText(SITE_NAMES[studies[0].study])
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(0)).getByText(studies[0].daysInStudy)
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(0)).getByText(studies[0].numOfParticipants)
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(0)).getByText(studies[0].updatedAt)
+    ).toBeInTheDocument()
+    expect(within(tableRow(1)).getByText(studies[1].study)).toBeInTheDocument()
+    expect(
+      within(tableRow(1)).getByText(SITE_NAMES[studies[1].study])
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(1)).getByText(studies[1].daysInStudy)
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(1)).getByText(studies[1].numOfParticipants)
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(1)).getByText(studies[1].updatedAt)
+    ).toBeInTheDocument()
+    expect(within(tableRow(2)).getByText(studies[2].study)).toBeInTheDocument()
+    expect(
+      within(tableRow(2)).getByText(SITE_NAMES[studies[2].study])
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(2)).getByText(studies[2].daysInStudy)
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(2)).getByText(studies[2].numOfParticipants)
+    ).toBeInTheDocument()
+    expect(
+      within(tableRow(2)).getByText(studies[2].updatedAt)
+    ).toBeInTheDocument()
+  })
+})

--- a/views/tables/StudiesTable/index.jsx
+++ b/views/tables/StudiesTable/index.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+import dayjs from 'dayjs'
+
+import { SITE_NAMES } from '../../../server/utils/siteNames'
+import Table from '../Table'
+
+const StudiesTable = (props) => {
+  const { onSort, studies, sortable, sortDirection, sortProperty } = props
+
+  const headers = [
+    {
+      dataProperty: 'study',
+      label: 'Study',
+      sortable: !!sortable,
+    },
+    {
+      dataProperty: 'siteName',
+      label: 'Site',
+      sortable: !!sortable,
+    },
+    {
+      dataProperty: 'daysInStudy',
+      label: 'Days In Study',
+      sortable: !!sortable,
+    },
+    {
+      dataProperty: 'numOfParticipants',
+      label: 'No. of Participants',
+      sortable: !!sortable,
+    },
+    {
+      dataProperty: 'updatedAt',
+      label: 'Last Updated',
+      sortable: !!sortable,
+    },
+  ]
+
+  const cellRenderer = (study, property) => {
+    switch (property) {
+      case 'updatedAt': {
+        return dayjs(study[property]).toISOString()
+      }
+      case 'siteName': {
+        return SITE_NAMES[study['study']]
+      }
+      default:
+        return study[property]
+    }
+  }
+
+  return (
+    <Table
+      cellRenderer={cellRenderer}
+      data={studies}
+      headers={headers}
+      sortDirection={sortDirection}
+      sortProperty={sortProperty}
+      handleRequestSort={onSort}
+    />
+  )
+}
+
+export default StudiesTable


### PR DESCRIPTION
This pr adds the studies table to the study page. I had to update the api endpoint for the study importer, to make sure we add the `updatedAt` property, if it's a new study then we add a createdAt and updatedAt property. 

The daysInStudy is calculated by using the highest daysInStudy value from a participant.

I updated a rule on the linter for optional chaining, without this it is causing charts not to load.

I verified the documentDB compatibility with the mongodb operators I am using for querying and sorting and they are compatible.

@mikestone14 We might need an updated list of the site names, there is RU site which we don't have a name for.

Video of the functionality. 

https://drive.google.com/file/d/16DC3F8UfdVSyvw2XJKcaoGU9rGsJ_9Km/view?usp=sharing