### PR TITLE
Remove explicit width from filter inputs

### DIFF
--- a/views/forms/ChartFilterForm/index.jsx
+++ b/views/forms/ChartFilterForm/index.jsx
@@ -53,7 +53,6 @@ const ChartFilterForm = ({ initialValues, onSubmit }) => {
               sx={{
                 gridColumnStart: i,
                 gridColumnEnd: i + 1,
-                width: '275px',
               }}
             >
               <InputLabel id={`multi-chip-label-${filterKey}`}>


### PR DESCRIPTION
This explicit width was causing the inputs to exceed the width of the screen, and have large gaps on wide screens.


### Before

![Screenshot 2024-04-05 at 10 20 19 AM](https://github.com/AMP-SCZ/dpdash/assets/2905145/9978acc0-15f9-4ea4-90da-6eb396badc34)

![Screenshot 2024-04-05 at 10 20 27 AM](https://github.com/AMP-SCZ/dpdash/assets/2905145/d8c8808b-afdd-420f-b2fb-154cd82d28d8)

### After

![Screenshot 2024-04-05 at 10 21 09 AM](https://github.com/AMP-SCZ/dpdash/assets/2905145/6ed41776-ef4f-448c-92fc-9f713e59b62c)

![Screenshot 2024-04-05 at 10 20 54 AM](https://github.com/AMP-SCZ/dpdash/assets/2905145/78024548-9ed0-43de-b1e5-9c737d4ddad2)
