### PR TITLE
Render Totals Row last on the charts table

### DIFF
--- a/views/pages/ViewChartPage/index.jsx
+++ b/views/pages/ViewChartPage/index.jsx
@@ -9,7 +9,7 @@ import FileSaver from 'file-saver'
 import qs from 'qs'
 import { useParams, useLocation, useNavigate } from 'react-router-dom'
 
-import { SORT_DIRECTION, fontSize } from '../../../constants'
+import { SORT_DIRECTION, fontSize, TOTALS } from '../../../constants'
 import api from '../../api'
 import BarGraph from '../../components/BarGraph'
 import ChartDescription from '../../components/ChartDescription'
@@ -119,6 +119,7 @@ const ViewChartPage = () => {
     setPage(0)
   }
   const graphTablePredicate = (a, b) => {
+    if (a[sortBy] === TOTALS || b[sortBy] === TOTALS) return 1
     if (b[sortBy] < a[sortBy]) {
       return sortDirection === SORT_DIRECTION.ASC ? 1 : -1
     }


### PR DESCRIPTION
This pr adds a condition to the table sort predicate that will always place the Totals table row at the end.

I think the screen capture does a better job at displaying the fix than a screenshot.

https://drive.google.com/file/d/15m9IJdWtBAEiJBmkWA9LSejnvkluT24H/view?usp=sharing
