### PR TITLE
Fix crash from tooltip

### DIFF
--- a/views/components/BarGraphTooltip/index.jsx
+++ b/views/components/BarGraphTooltip/index.jsx
@@ -14,10 +14,10 @@ const BarGraphTooltip = ({
 }) => {
   if (!active || !payload?.length) return null
 
-  const siteName = useSiteName ? label : SITE_NAMES[label]
+  const siteName = useSiteName ? label : SITE_NAMES[label] || label
   const countsTotal = useSiteName
     ? studyTotals[label].count
-    : studyTotals[SITE_NAMES[label]].count
+    : studyTotals[SITE_NAMES[label] || label].count
   const variableCounts = payload[0].payload.counts
 
   return (

--- a/views/components/BarGraphTooltip/index.jsx
+++ b/views/components/BarGraphTooltip/index.jsx
@@ -15,9 +15,7 @@ const BarGraphTooltip = ({
   if (!active || !payload?.length) return null
 
   const siteName = useSiteName ? label : SITE_NAMES[label] || label
-  const countsTotal = useSiteName
-    ? studyTotals[label].count
-    : studyTotals[SITE_NAMES[label] || label].count
+  const countsTotal = studyTotals[siteName].count
   const variableCounts = payload[0].payload.counts
 
   return (

--- a/views/pages/ViewChartPage/index.jsx
+++ b/views/pages/ViewChartPage/index.jsx
@@ -25,7 +25,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(advanced)
 
-const tooltipWidth = 190
+const tooltipWidth = 235
 const staticYPosition = 75
 
 const ViewChartPage = () => {


### PR DESCRIPTION
closes #725 

This pr fixes an issue that happens when a user is hovering over the bar graph some bars may cause it to crash.
If you see in the video as I get further to the right, so does the tooltip and it passes the edge of bar graph, this change here
`const tooltipWidth = 235` places the tooltip a little more to the left.

[Video of bug fix Part I](https://drive.google.com/file/d/1utvjOz65jk0UocEB2bLCwg7ezLELFXQ5/view?usp=sharing)