### PR TITLE
Saving a Matrix view saves an empty PNG

### DIFF
--- a/views/components/Graph/index.jsx
+++ b/views/components/Graph/index.jsx
@@ -120,11 +120,9 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
   }, [user.preferences.config])
 
   React.useEffect(() => {
-    if (isGraphLoaded) setIsGraphLoaded(false)
+    if (isGraphLoaded) {
+      const updatedSvgElement = graphRef.current.lastChild
 
-    const updatedSvgElement = graphRef.current.lastChild
-
-    if (updatedSvgElement) {
       const svgString = new XMLSerializer().serializeToString(updatedSvgElement)
 
       const kanvas = canvasRef.current
@@ -148,6 +146,8 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
       img.onload = () => {
         ctx.drawImage(img, 0, 0)
       }
+
+      setIsGraphLoaded(false)
     }
   }, [isGraphLoaded])
 

--- a/views/components/Graph/index.jsx
+++ b/views/components/Graph/index.jsx
@@ -21,7 +21,7 @@ import Matrix from '../Matrix.d3'
 const cardSize = 20
 
 export const Graph = ({ study, subject, user, theme, setNotification }) => {
-  const [isGraphLoaded, setIsGraphLoaded] = useState(false)
+  const [shoulDrawPng, setShouldDrawPng] = useState(false)
   const canvasRef = useRef()
   const graphRef = createRef()
   const [openStat, setOpenStat] = React.useState(false)
@@ -112,7 +112,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
     graphRef.current = new Matrix(graphRef.current, matrixProps)
     graphRef.current.create(graph.matrixData)
 
-    setIsGraphLoaded(true)
+    setShouldDrawPng(true)
   }
 
   React.useEffect(() => {
@@ -120,7 +120,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
   }, [user.preferences.config])
 
   React.useEffect(() => {
-    if (isGraphLoaded) {
+    if (shoulDrawPng) {
       const updatedSvgElement = graphRef.current.lastChild
 
       const svgString = new XMLSerializer().serializeToString(updatedSvgElement)
@@ -147,9 +147,9 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
         ctx.drawImage(img, 0, 0)
       }
 
-      setIsGraphLoaded(false)
+      setShouldDrawPng(false)
     }
-  }, [isGraphLoaded])
+  }, [shoulDrawPng])
 
   React.useEffect(() => {
     renderMatrix(graph)

--- a/views/components/Graph/index.jsx
+++ b/views/components/Graph/index.jsx
@@ -1,4 +1,4 @@
-import React, { createRef, useRef } from 'react'
+import React, { createRef, useRef, useState } from 'react'
 
 import { Save, Functions } from '@mui/icons-material'
 import {
@@ -21,6 +21,7 @@ import Matrix from '../Matrix.d3'
 const cardSize = 20
 
 export const Graph = ({ study, subject, user, theme, setNotification }) => {
+  const [isGraphLoaded, setIsGraphLoaded] = useState(false)
   const canvasRef = useRef()
   const graphRef = createRef()
   const [openStat, setOpenStat] = React.useState(false)
@@ -109,8 +110,9 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
     }
 
     graphRef.current = new Matrix(graphRef.current, matrixProps)
-
     graphRef.current.create(graph.matrixData)
+
+    setIsGraphLoaded(true)
   }
 
   React.useEffect(() => {
@@ -118,11 +120,10 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
   }, [user.preferences.config])
 
   React.useEffect(() => {
-    if (!graphRef.current) {
-      return
-    }
+    if (isGraphLoaded) setIsGraphLoaded(false)
 
     const updatedSvgElement = graphRef.current.lastChild
+
     if (updatedSvgElement) {
       const svgString = new XMLSerializer().serializeToString(updatedSvgElement)
 
@@ -148,7 +149,7 @@ export const Graph = ({ study, subject, user, theme, setNotification }) => {
         ctx.drawImage(img, 0, 0)
       }
     }
-  }, [graphRef])
+  }, [isGraphLoaded])
 
   React.useEffect(() => {
     renderMatrix(graph)


### PR DESCRIPTION
This pr fixes the following, when a user saves a matrix view, that png is empty.

To fix this we wait until the matrix graph is created and the svg element is present, then we draw the canvas.

[Functionality Video](https://drive.google.com/file/d/1gqx3EcQQyl4OxglGBMFPSXPY0mMkok2P/view?usp=sharing)