### PR TITLE
Allow users to save configurations as draft

### DIFF
--- a/server/models/ConfigModel/index.js
+++ b/server/models/ConfigModel/index.js
@@ -4,6 +4,21 @@ import defaultUserConfig from '../../constants/defaultUserConfig'
 import { collections } from '../../utils/mongoCollections'
 
 const ConfigModel = {
+  active: async (db, userId) =>
+    await db
+      .collection(collections.configs)
+      .aggregate([
+        { $match: { $or: [{ readers: userId }, { public: true }] } },
+        {
+          $match: { $or: [{ status: { $exists: false } }, { status: 1 }] },
+        },
+      ])
+      .stream(),
+  all: async (db, userId) =>
+    await db
+      .collection(collections.configs)
+      .find({ $or: [{ readers: userId }, { public: true }] })
+      .stream(),
   destroy: async (db, configId) => {
     const { deletedCount } = await db
       .collection(collections.configs)
@@ -28,11 +43,7 @@ const ConfigModel = {
 
     return value
   },
-  index: async (db, userId) =>
-    await db
-      .collection(collections.configs)
-      .find({ $or: [{ readers: userId }, { public: true }] })
-      .stream(),
+
   create: async (db, configAttributes) => {
     const { insertedId } = await db
       .collection(collections.configs)

--- a/server/routes/configurations.js
+++ b/server/routes/configurations.js
@@ -27,6 +27,7 @@ const body = yup.object({
       })
     ),
   }),
+  status: yup.number(),
 })
 const params = yup.object({
   config_id: yup.string().required(),
@@ -35,6 +36,9 @@ const allSchema = baseSchema({
   params: yup.object({
     uid: yup.string().required(),
   }),
+  query: yup.object({
+    status: yup.string(),
+  }),
 })
 const configurationSchema = baseSchema({ body })
 const paramsSchema = baseSchema({ params })
@@ -42,6 +46,7 @@ const updateSchema = baseSchema({
   params,
   body,
 })
+
 router
   .route(v1Routes.config.index)
   .get(validateRequest(allSchema), ensureUser, ConfigurationsController.index)

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -153,6 +153,7 @@ export const createConfiguration = (overrides = {}) => ({
   type: 'matrix',
   created: 'Mon, 12 June 2023',
   readers: ['owl'],
+  status: 1,
   ...overrides,
 })
 

--- a/views/App.jsx
+++ b/views/App.jsx
@@ -10,11 +10,7 @@ import {
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 
-import {
-  AuthContext,
-  ConfigurationsContext,
-  NotificationContext,
-} from './contexts'
+import { AuthContext, NotificationContext } from './contexts'
 import Router from './routes'
 import { NOTIFICATION_DEFAULT, THEME } from '../constants'
 
@@ -23,7 +19,6 @@ import './App.css'
 const theme = createTheme(THEME)
 
 const App = () => {
-  const [configurations, setConfigurations] = useState([])
   const [notification, setNotification] = useState(NOTIFICATION_DEFAULT)
   const [user, setUser] = useState(null)
 
@@ -31,27 +26,23 @@ const App = () => {
 
   return (
     <NotificationContext.Provider value={[notification, setNotification]}>
-      <ConfigurationsContext.Provider
-        value={[configurations, setConfigurations]}
-      >
-        <AuthContext.Provider value={[user, setUser]}>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <ThemeProvider theme={theme}>
-              <CssBaseline />
-              <StyledEngineProvider injectFirst>
-                <Router user={user} setUser={setUser} />
-                <Snackbar
-                  open={notification.open}
-                  message={notification.message}
-                  autoHideDuration={2000}
-                  onClose={handleNotificationClose}
-                  anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
-                />
-              </StyledEngineProvider>
-            </ThemeProvider>
-          </LocalizationProvider>
-        </AuthContext.Provider>
-      </ConfigurationsContext.Provider>
+      <AuthContext.Provider value={[user, setUser]}>
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <StyledEngineProvider injectFirst>
+              <Router user={user} setUser={setUser} />
+              <Snackbar
+                open={notification.open}
+                message={notification.message}
+                autoHideDuration={2000}
+                onClose={handleNotificationClose}
+                anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
+              />
+            </StyledEngineProvider>
+          </ThemeProvider>
+        </LocalizationProvider>
+      </AuthContext.Provider>
     </NotificationContext.Provider>
   )
 }

--- a/views/api/userConfigurations/index.js
+++ b/views/api/userConfigurations/index.js
@@ -2,8 +2,8 @@ import { apiRoutes } from '../../routes/routes'
 import http from '../http'
 
 const userConfigurations = {
-  all: async (userId) =>
-    http.get(apiRoutes.configurations.userConfigurations(userId)),
+  all: async (userId, queryParams) =>
+    http.get(apiRoutes.configurations.userConfigurations(userId), queryParams),
   create: async (userId, configAttributes) =>
     http.post(
       apiRoutes.configurations.userConfigurations(userId),

--- a/views/contexts/ConfigurationsContext.js
+++ b/views/contexts/ConfigurationsContext.js
@@ -1,3 +1,0 @@
-import { createContext } from 'react'
-
-export const ConfigurationsContext = createContext()

--- a/views/contexts/index.js
+++ b/views/contexts/index.js
@@ -1,6 +1,5 @@
 import { AuthContext } from './AuthContext'
-import { ConfigurationsContext } from './ConfigurationsContext'
 import { NotificationContext } from './NotificationContext'
 import { ThemeContext } from './ThemeContext'
 
-export { AuthContext, ConfigurationsContext, NotificationContext, ThemeContext }
+export { AuthContext, NotificationContext, ThemeContext }

--- a/views/forms/ConfigForm/ConfigForm.css
+++ b/views/forms/ConfigForm/ConfigForm.css
@@ -1,7 +1,11 @@
 .ConfigFormActions {
   position: fixed;
-  top: 0;
+  bottom: 0;
   right: 0;
   border: 0;
   padding: 24px;
+  display: grid;
+  grid-template-columns: repeat(1fr, 3);
+  gap: 10px;
+  font-size: 12px;
 }

--- a/views/forms/ConfigForm/index.jsx
+++ b/views/forms/ConfigForm/index.jsx
@@ -1,8 +1,7 @@
 import React from 'react'
 
 import { yupResolver } from '@hookform/resolvers/yup'
-import { AddCircleOutline, Save } from '@mui/icons-material'
-import { Fab } from '@mui/material'
+import { Button } from '@mui/material'
 import { useForm } from 'react-hook-form'
 import * as yup from 'yup'
 
@@ -35,6 +34,7 @@ const schema = yup.object({
       text: yup.boolean(),
     })
   ),
+  status: yup.number(),
 })
 
 const ConfigForm = ({
@@ -45,6 +45,7 @@ const ConfigForm = ({
   assessmentOptions,
   handleClearAssessments,
   handleAssessmentSearch,
+  handleSubmitDraft,
 }) => {
   const defaultFieldValue = UserConfigModel.defaultConfigValues
 
@@ -75,12 +76,51 @@ const ConfigForm = ({
         handleClearAssessments={handleClearAssessments}
       />
       <div className="ConfigFormActions">
-        <Fab color="primary" onClick={() => addNewField()} sx={{ p: '5px' }}>
-          <AddCircleOutline />
-        </Fab>
-        <Fab type="submit" sx={{ p: '5px' }}>
-          <Save />
-        </Fab>
+        <Button
+          color="secondary"
+          size="small"
+          disableElevation
+          variant="contained"
+          onClick={() => addNewField()}
+          sx={{ gridColumnStart: 1, gridColumnEnd: 1 }}
+        >
+          Add a field
+        </Button>
+        <Button
+          disableElevation
+          onClick={handleSubmit(handleSubmitDraft)}
+          sx={{
+            backgroundColor: 'grey.A400',
+            gridColumnStart: 2,
+            gridColumnEnd: 2,
+            '&:active': {
+              backgroundColor: 'grey.A400',
+            },
+            '&:hover': {
+              backgroundColor: 'grey.A200',
+            },
+          }}
+          variant="contained"
+          size="small"
+        >
+          Save as draft
+        </Button>
+        <Button
+          type="submit"
+          size="small"
+          disableElevation
+          sx={{
+            backgroundColor: 'primary.dark',
+            '&:active': {
+              backgroundColor: 'primary.dark',
+            },
+            gridColumnStart: 3,
+            gridColumnEnd: 3,
+          }}
+          variant="contained"
+        >
+          Publish
+        </Button>
       </div>
     </form>
   )

--- a/views/layouts/MainLayout/index.jsx
+++ b/views/layouts/MainLayout/index.jsx
@@ -6,17 +6,12 @@ import { Outlet, useNavigate } from 'react-router-dom'
 
 import api from '../../api'
 import Sidebar from '../../components/Sidebar'
-import {
-  AuthContext,
-  ConfigurationsContext,
-  NotificationContext,
-} from '../../contexts'
+import { AuthContext, NotificationContext } from '../../contexts'
 import { routes } from '../../routes/routes'
 import './MainLayout.css'
 
 const MainLayout = () => {
   const isMobile = useMediaQuery('(max-width:900px)')
-  const [configurations, setConfigurations] = useContext(ConfigurationsContext)
   const [, setNotification] = useContext(NotificationContext)
   const [user, setUser] = useContext(AuthContext)
   const [users, setUsers] = useState([])
@@ -26,15 +21,6 @@ const MainLayout = () => {
     try {
       const usersList = await api.users.loadAll()
       setUsers(usersList)
-    } catch (error) {
-      setNotification({ open: true, message: error.message })
-    }
-  }
-  const loadAllConfigurations = async () => {
-    try {
-      const configurations = await api.userConfigurations.all(user.uid)
-
-      setConfigurations(configurations)
     } catch (error) {
       setNotification({ open: true, message: error.message })
     }
@@ -49,12 +35,13 @@ const MainLayout = () => {
       alert(error.message)
     }
   }
-  useEffect(() => {
-    fetchUsers()
-    loadAllConfigurations()
-  }, [])
   const handleDrawerOpen = () => setDrawerOpen(!drawerOpen)
   const handleClose = () => setDrawerOpen(false)
+
+  useEffect(() => {
+    fetchUsers()
+  }, [])
+
   return (
     <div className="MainLayout_container">
       {isMobile && (
@@ -80,9 +67,7 @@ const MainLayout = () => {
       <main className="MainLayout_main">
         <Outlet
           context={{
-            configurations,
             navigate,
-            setConfigurations,
             setNotification,
             setUser,
             setUsers,

--- a/views/models/UserConfigModel/UserConfigModel.test.js
+++ b/views/models/UserConfigModel/UserConfigModel.test.js
@@ -24,7 +24,7 @@ describe('Models - User Config', () => {
     })
 
     it('returns config form values as user config object', () => {
-      const newUserConfig = UserConfigModel.processNewConfig(
+      const newUserConfig = UserConfigModel.publishConfig(
         formValues,
         colors,
         'owl'
@@ -58,6 +58,7 @@ describe('Models - User Config', () => {
         readers: ['fang', 'talon', 'mabel'],
         type: 'matrix',
         public: false,
+        status: 1,
       })
     })
   })

--- a/views/models/UserConfigModel/index.js
+++ b/views/models/UserConfigModel/index.js
@@ -18,26 +18,14 @@ const UserConfigModel = {
     public: false,
     ...overrides,
   }),
-  processNewConfig: (formValues, colors, owner) => {
-    const config = {
-      0: formValues.config.map(({ min, max, color, ...rest }) => {
-        return {
-          color: colors.find(({ value }) => value === color).label,
-          range: [min, max],
-          ...rest,
-        }
-      }),
-    }
-
-    return {
-      config,
-      name: formValues.configName,
-      owner,
-      type: formValues.configType,
-      readers: formValues.readers.map(({ value }) => value),
-      public: formValues.public,
-    }
-  },
+  publishConfig: (formValues, colors, owner) => ({
+    ...processConfigAssessment(formValues, colors, owner),
+    status: 1,
+  }),
+  saveAsDraft: (formValues, colors, owner) => ({
+    ...processConfigAssessment(formValues, colors, owner),
+    status: 0,
+  }),
   processConfigToFormFields: (currentConfig, colors) => {
     const {
       config,
@@ -78,9 +66,30 @@ const UserConfigModel = {
       public: publicConfig,
     }
   },
+  isActive: (configuration, property) =>
+    configuration[property] === 1 || !Object.hasOwn(configuration, property),
 }
 
 export const findCategoryColor = (categoryColors, colors) =>
   colors.find(({ label }) => categoryColors.every((el, i) => el === label[i]))
+
+const processConfigAssessment = (formValues, colors, owner) => {
+  return {
+    config: {
+      0: formValues.config.map(({ min, max, color, ...rest }) => {
+        return {
+          color: colors.find(({ value }) => value === color).label,
+          range: [min, max],
+          ...rest,
+        }
+      }),
+    },
+    name: formValues.configName,
+    owner,
+    type: formValues.configType,
+    readers: formValues.readers.map(({ value }) => value),
+    public: formValues.public,
+  }
+}
 
 export default UserConfigModel

--- a/views/pages/ConfigurationsPage/index.jsx
+++ b/views/pages/ConfigurationsPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { Add, UploadFile } from '@mui/icons-material'
 import { Box, Button, useMediaQuery } from '@mui/material'
@@ -16,16 +16,9 @@ import './ConfigurationsPage.css'
 
 const ConfigurationsPage = () => {
   const isMobile = useMediaQuery('(max-width:900px)')
-  const {
-    configurations,
-    navigate,
-    setNotification,
-    setConfigurations,
-    setUser,
-    user,
-    users,
-  } = useOutletContext()
+  const { navigate, setNotification, setUser, user, users } = useOutletContext()
   const { uid, preferences } = user
+  const [configurations, setConfigurations] = useState([])
   const [configuration, setConfiguration] = useState(null)
   const open = !!configuration?._id
   const options =
@@ -71,6 +64,7 @@ const ConfigurationsPage = () => {
       handleNotification(error.message)
     }
   }
+
   const closeForm = () => setConfiguration(null)
 
   const handleFormModal = async (config) => setConfiguration(config)
@@ -112,6 +106,7 @@ const ConfigurationsPage = () => {
         ...configAttributes,
         owner: uid,
         readers: [uid],
+        status: 1,
       }
 
       await api.userConfigurations.create(uid, newConfig)
@@ -134,6 +129,7 @@ const ConfigurationsPage = () => {
           owner: user.uid,
           readers: [user.uid],
           type: 'matrix',
+          status: 1,
         }
 
         await api.userConfigurations.create(
@@ -149,6 +145,9 @@ const ConfigurationsPage = () => {
     }
   }
 
+  useEffect(() => {
+    loadAllConfigurations(uid)
+  }, [])
   return (
     <Box sx={{ p: '20px' }}>
       <PageHeader

--- a/views/pages/EditConfigPage.jsx
+++ b/views/pages/EditConfigPage.jsx
@@ -19,9 +19,9 @@ const EditConfigPage = () => {
   const friendsList = UsersModel.createUserFriendList(users, user)
   const { uid } = user
 
-  const handleSubmit = async (formValues) => {
+  const handleSubmitPublish = async (formValues) => {
     try {
-      const updatedConfiguration = UserConfigModel.processNewConfig(
+      const updatedConfiguration = UserConfigModel.publishConfig(
         formValues,
         colors,
         uid
@@ -64,20 +64,37 @@ const EditConfigPage = () => {
       setLoading(false)
     })
   }, [])
+  const handleSubmitDraft = async (formValues) => {
+    const newConfigurationAttributes = UserConfigModel.saveAsDraft(
+      formValues,
+      colors,
+      uid
+    )
+    await api.userConfigurations.update(
+      uid,
+      config_id,
+      newConfigurationAttributes
+    )
 
+    setNotification({
+      open: true,
+      message: 'Draft saved',
+    })
+  }
   if (loading) return <div>Depending on the size, this may take a while...</div>
 
   return (
     <Box sx={{ p: '30px' }}>
       <Typography variant="h6">Edit Configuration</Typography>
       <ConfigForm
+        assessmentOptions={assessmentOptions}
         colors={colors}
         friendsList={friendsList}
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmitPublish}
         initialValues={initialValues}
-        assessmentOptions={assessmentOptions}
         handleClearAssessments={handleClearAssessments}
         handleAssessmentSearch={handleAssessmentSearch}
+        handleSubmitDraft={handleSubmitDraft}
       />
     </Box>
   )

--- a/views/pages/GraphPage.jsx
+++ b/views/pages/GraphPage.jsx
@@ -9,8 +9,8 @@ import PageHeader from '../components/PageHeader'
 import SelectConfigurationForm from '../components/SelectConfigurationForm'
 
 const GraphPage = () => {
-  const { configurations, user, theme, setUser, setNotification } =
-    useOutletContext()
+  const { user, theme, setUser, setNotification } = useOutletContext()
+  const [configurations, setConfigurations] = useState([])
   const { study, subject } = useParams()
   const [participants, setParticipants] = useState([])
 
@@ -28,10 +28,15 @@ const GraphPage = () => {
     }
   }
 
-  useEffect(() => {
-    fetchParticipants()
-  }, [study, subject])
+  const loadActiveConfigurations = async () => {
+    const queryParams = { status: 'active' }
+    const configurations = await api.userConfigurations.all(
+      user.uid,
+      queryParams
+    )
 
+    setConfigurations(configurations)
+  }
   const updateUserPreferences = async (configurationId) => {
     try {
       const { uid } = user
@@ -48,6 +53,14 @@ const GraphPage = () => {
       setNotification({ open: true, message: error.message })
     }
   }
+
+  useEffect(() => {
+    loadActiveConfigurations()
+  }, [])
+
+  useEffect(() => {
+    fetchParticipants()
+  }, [study, subject])
 
   return (
     <Box sx={{ p: '20px' }}>

--- a/views/pages/NewConfigPage.jsx
+++ b/views/pages/NewConfigPage.jsx
@@ -20,9 +20,9 @@ const NewConfigPage = () => {
   })
   const friendsList = UsersModel.createUserFriendList(users, user)
 
-  const handleFormData = async (formValues) => {
+  const handleSubmitPublish = async (formValues) => {
     try {
-      const newConfigurationAttributes = UserConfigModel.processNewConfig(
+      const newConfigurationAttributes = UserConfigModel.publishConfig(
         formValues,
         colors,
         uid
@@ -50,17 +50,32 @@ const NewConfigPage = () => {
 
   const handleClear = async () => setAssessmentOptions([])
 
+  const handleSubmitDraft = async (formValues) => {
+    const newConfigurationAttributes = UserConfigModel.saveAsDraft(
+      formValues,
+      colors,
+      uid
+    )
+    await api.userConfigurations.create(uid, newConfigurationAttributes)
+
+    setNotification({
+      open: true,
+      message: 'Draft saved',
+    })
+  }
+
   return (
     <Box sx={{ p: '30px' }}>
       <Typography variant="h6">New Configuration</Typography>
       <ConfigForm
         colors={colors}
         friendsList={friendsList}
-        onSubmit={handleFormData}
+        onSubmit={handleSubmitPublish}
         initialValues={defaultValues}
         assessmentOptions={assessmentOptions}
         handleClear={handleClear}
         handleAssessmentSearch={handleAssessmentSearch}
+        handleSubmitDraft={handleSubmitDraft}
       />
     </Box>
   )

--- a/views/routes/routes.js
+++ b/views/routes/routes.js
@@ -73,6 +73,7 @@ export const apiRoutes = {
         : `${apiPath}/charts/${chartId}/data`,
   },
   configurations: {
+    activeUserConfigurations: (uid) => `${apiPath}/users/${uid}/active-configs`,
     userConfigurations: (uid) => `${apiPath}/users/${uid}/configs`,
     userConfiguration: (uid, config_id) =>
       `${apiRoutes.configurations.userConfigurations(uid)}/${config_id}`,

--- a/views/tables/ConfigurationsTable/index.jsx
+++ b/views/tables/ConfigurationsTable/index.jsx
@@ -10,9 +10,9 @@ import {
 import { Chip } from '@mui/material'
 
 import { borderRadius, fontSize } from '../../../constants'
+import { UserConfigModel } from '../../models'
 import Table from '../Table'
 import TableMenu from '../Table/TableMenu'
-import { UserConfigModel } from '../../models'
 
 const ConfigurationsTable = (props) => {
   const {

--- a/views/tables/ConfigurationsTable/index.jsx
+++ b/views/tables/ConfigurationsTable/index.jsx
@@ -12,6 +12,7 @@ import { Chip } from '@mui/material'
 import { borderRadius, fontSize } from '../../../constants'
 import Table from '../Table'
 import TableMenu from '../Table/TableMenu'
+import { UserConfigModel } from '../../models'
 
 const ConfigurationsTable = (props) => {
   const {
@@ -29,6 +30,11 @@ const ConfigurationsTable = (props) => {
     {
       dataProperty: 'owner_display_name',
       label: 'Created By',
+      sortable: false,
+    },
+    {
+      dataProperty: 'status',
+      label: 'Status',
       sortable: false,
     },
     {
@@ -102,7 +108,32 @@ const ConfigurationsTable = (props) => {
             ]}
           />
         )
-
+      case 'status':
+        return UserConfigModel.isActive(configuration, property) ? (
+          <Chip
+            sx={{
+              backgroundColor: 'primary.light',
+              color: 'text.secondary',
+              fontSize: fontSize[14],
+              fontWeight: 500,
+              p: '0 19px 0 15px',
+              borderRadius: borderRadius[24],
+            }}
+            label="Active"
+          />
+        ) : (
+          <Chip
+            sx={{
+              backgroundColor: 'grey.A300',
+              color: 'text.primary',
+              fontSize: fontSize[14],
+              fontWeight: 500,
+              p: '0 19px 0 15px',
+              borderRadius: borderRadius[24],
+            }}
+            label="Draft"
+          />
+        )
       default:
         return configuration[property]
     }


### PR DESCRIPTION
This pr adds the following functionality: 
* allow users to save a configuration as a draft
* Draft configurations do not show up as usable options in places where configurations are selected
* Adds a column to the configurations table on the Configurations Listing Page for "status" and display statuses as active/draft

[Usability Video](https://drive.google.com/file/d/1DWdY8YDBz4drQgYA9qoy5whcPB3sT_0A/view?usp=sharing)