### PR TITLE
Funnel to error logger

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -172,6 +172,8 @@ app.get('/*', async (req, res) => {
     path.join(__dirname, '..', 'public', 'index.html'),
     (err) => {
       if (err) {
+        console.error(err)
+
         res.status(500).send(err)
       }
     }

--- a/server/app.js
+++ b/server/app.js
@@ -183,7 +183,7 @@ app.get('/*', async (req, res) => {
 //catch any other error
 app.use(function (err, _req, res) {
   if (err) {
-    console.error(err)
+    console.error('=====Error====== \n' + err)
     return res.status(err.status).json({ error: err.message })
   }
 })

--- a/server/app.js
+++ b/server/app.js
@@ -183,7 +183,7 @@ app.get('/*', async (req, res) => {
 //catch any other error
 app.use(function (err, _req, res) {
   if (err) {
-    console.error('=====Error====== \n' + err)
+    console.log('=====Error======', err)
     return res.status(err.status).json({ error: err.message })
   }
 })

--- a/server/controllers/api/assessmentDayDataController/assessmentDayDataController.test.js
+++ b/server/controllers/api/assessmentDayDataController/assessmentDayDataController.test.js
@@ -406,27 +406,6 @@ describe('assessmentDayDataController', () => {
           message: 'Nothing to import',
         })
       })
-
-      it('returns a status of 400 and an error message', async () => {
-        const request = createRequest({
-          body: {
-            metadata: createAssessmentDayDataMetadata(),
-            participant_assessments: [{}],
-          },
-        })
-        const response = createResponse()
-
-        request.app.locals.appDb.findOne.mockRejectedValueOnce(
-          new Error('some error')
-        )
-
-        await AssessmentDayDataController.create(request, response)
-
-        expect(response.status).toHaveBeenCalledWith(400)
-        expect(response.json).toHaveBeenCalledWith({
-          message: 'some error',
-        })
-      })
     })
   })
   describe(AssessmentDayDataController.destroy, () => {

--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -6,160 +6,153 @@ import { collections } from '../../../utils/mongoCollections'
 
 const AssessmentDayDataController = {
   create: async (req, res) => {
+    const { appDb } = req.app.locals
+    const { metadata, participant_assessments, assessment_variables } = req.body
+
+    if (!metadata || !participant_assessments.length)
+      return res.status(400).json({ message: 'Nothing to import' })
+
+    const { assessment, participant, study, Consent, Active } = metadata
+    let parsedConsent = null
+
     try {
-      const { appDb } = req.app.locals
-      const { metadata, participant_assessments, assessment_variables } =
-        req.body
-
-      if (!metadata || !participant_assessments.length)
-        return res.status(400).json({ message: 'Nothing to import' })
-
-      const { assessment, participant, study, Consent, Active } = metadata
-      let parsedConsent = null
-
-      try {
-        if (Consent) {
-          parsedConsent = new Date(Consent)
-        }
-      } catch {
-        // Missing consent dates could come in a number of formats,
-        // so we attempt to parse the date and leave it as null if there's
-        // an error
+      if (Consent) {
+        parsedConsent = new Date(Consent)
       }
+    } catch {
+      // Missing consent dates could come in a number of formats,
+      // so we attempt to parse the date and leave it as null if there's
+      // an error
+    }
 
-      const query = {
-        assessment,
-        participant,
-      }
-      const assessmentQuery = {
-        name: assessment,
-      }
-      const newAssessmentProperties = AssessmentModel.withDefaults({
-        name: assessment,
+    const query = {
+      assessment,
+      participant,
+    }
+    const assessmentQuery = {
+      name: assessment,
+    }
+    const newAssessmentProperties = AssessmentModel.withDefaults({
+      name: assessment,
+    })
+
+    const participantAssessmentData = await AssessmentDayDataModel.findOne(
+      appDb,
+      query
+    )
+
+    let sortedDayData = participant_assessments
+    let maxDayInDayData = Math.max(
+      ...participant_assessments.map((pa) => pa.day)
+    )
+
+    if (participantAssessmentData) {
+      sortedDayData = sortDayData(
+        participantAssessmentData,
+        participant_assessments
+      )
+      maxDayInDayData = Math.max(...sortedDayData.map((dayData) => dayData.day))
+
+      await AssessmentDayDataModel.update(appDb, query, {
+        ...participantAssessmentData,
+        ...metadata,
+        Consent: parsedConsent,
+        daysInStudy: maxDayInDayData,
+        dayData: sortedDayData,
       })
+    } else {
+      await AssessmentDayDataModel.create(appDb, {
+        ...metadata,
+        Consent: parsedConsent,
+        dayData: participant_assessments,
+      })
+    }
 
-      const participantAssessmentData = await AssessmentDayDataModel.findOne(
+    const studyMetadata = await SiteMetadataModel.findOne(appDb, {
+      study,
+    })
+
+    if (!studyMetadata) {
+      await SiteMetadataModel.upsert(
         appDb,
-        query
+        { study },
+        {
+          setAttributes: {
+            study,
+            participants: [
+              {
+                Active,
+                Consent: parsedConsent,
+                study,
+                participant,
+                daysInStudy: maxDayInDayData,
+                synced: new Date(),
+              },
+            ],
+          },
+        }
       )
-
-      let sortedDayData = participant_assessments
-      let maxDayInDayData = Math.max(
-        ...participant_assessments.map((pa) => pa.day)
-      )
-
-      if (participantAssessmentData) {
-        sortedDayData = sortDayData(
-          participantAssessmentData,
-          participant_assessments
-        )
-        maxDayInDayData = Math.max(
-          ...sortedDayData.map((dayData) => dayData.day)
-        )
-
-        await AssessmentDayDataModel.update(appDb, query, {
-          ...participantAssessmentData,
-          ...metadata,
-          Consent: parsedConsent,
-          daysInStudy: maxDayInDayData,
-          dayData: sortedDayData,
-        })
-      } else {
-        await AssessmentDayDataModel.create(appDb, {
-          ...metadata,
-          Consent: parsedConsent,
-          dayData: participant_assessments,
-        })
-      }
-
-      const studyMetadata = await SiteMetadataModel.findOne(appDb, {
-        study,
+    } else {
+      const isParticipantInDocument = await SiteMetadataModel.findOne(appDb, {
+        participants: { $elemMatch: { participant } },
       })
-
-      if (!studyMetadata) {
+      if (isParticipantInDocument) {
         await SiteMetadataModel.upsert(
           appDb,
-          { study },
+          { participants: { $elemMatch: { participant } } },
           {
             setAttributes: {
-              study,
-              participants: [
-                {
-                  Active,
-                  Consent: parsedConsent,
-                  study,
-                  participant,
-                  daysInStudy: maxDayInDayData,
-                  synced: new Date(),
-                },
-              ],
+              'participants.$.daysInStudy': maxDayInDayData,
+              'participants.$.synced': new Date(),
             },
           }
         )
       } else {
-        const isParticipantInDocument = await SiteMetadataModel.findOne(appDb, {
-          participants: { $elemMatch: { participant } },
-        })
-        if (isParticipantInDocument) {
-          await SiteMetadataModel.upsert(
-            appDb,
-            { participants: { $elemMatch: { participant } } },
-            {
-              setAttributes: {
-                'participants.$.daysInStudy': maxDayInDayData,
-                'participants.$.synced': new Date(),
+        await SiteMetadataModel.upsert(
+          appDb,
+          { study },
+          {
+            addToSetAttributes: {
+              participants: {
+                Active,
+                Consent: parsedConsent,
+                daysInStudy: maxDayInDayData,
+                study,
+                participant,
+                synced: new Date(),
               },
-            }
-          )
-        } else {
-          await SiteMetadataModel.upsert(
-            appDb,
-            { study },
-            {
-              addToSetAttributes: {
-                participants: {
-                  Active,
-                  Consent: parsedConsent,
-                  daysInStudy: maxDayInDayData,
-                  study,
-                  participant,
-                  synced: new Date(),
-                },
-              },
-            }
-          )
-        }
-      }
-
-      const currentAssessment = await AssessmentModel.upsert(
-        appDb,
-        assessmentQuery,
-        newAssessmentProperties
-      )
-
-      if (assessment_variables.length) {
-        await Promise.all(
-          assessment_variables.map(async ({ name }) => {
-            const variableAttributes = {
-              name,
-              assessment_id: currentAssessment._id,
-            }
-
-            return await AssessmentVariablesModel.upsert(
-              appDb,
-              variableAttributes,
-              variableAttributes
-            )
-          })
+            },
+          }
         )
       }
-
-      return res
-        .status(200)
-        .json({ data: `${participant} ${assessment} data imported` })
-    } catch (error) {
-      return res.status(400).json({ message: error.message })
     }
+
+    const currentAssessment = await AssessmentModel.upsert(
+      appDb,
+      assessmentQuery,
+      newAssessmentProperties
+    )
+
+    if (assessment_variables.length) {
+      await Promise.all(
+        assessment_variables.map(async ({ name }) => {
+          const variableAttributes = {
+            name,
+            assessment_id: currentAssessment._id,
+          }
+
+          return await AssessmentVariablesModel.upsert(
+            appDb,
+            variableAttributes,
+            variableAttributes
+          )
+        })
+      )
+    }
+
+    return res
+      .status(200)
+      .json({ data: `${participant} ${assessment} data imported` })
   },
   destroy: async (req, res) => {
     try {


### PR DESCRIPTION
This pr makes use of the catch all error middleware in the application. This is because in the aws log when a controller has an error it is not printed to the console and poses a challenge when troubleshooting aws logs for errors.

In the controller I removed the try/catch block so that the exception is now handled by the middleware.

