### PR TITLE
feat: Add raw data endpoint for assessments

### DIFF
--- a/server/controllers/assessmentsController/index.js
+++ b/server/controllers/assessmentsController/index.js
@@ -20,6 +20,25 @@ const assessmentsController = {
       return res.status(401).json({ error: error.message })
     }
   },
+  raw: async (req, res) => {
+    try {
+      const { appDb } = req.app.locals
+      const { assessment, variable } = req.params
+
+      console.log(req.params)
+      console.log('Assesment : ', assessment, 'Variable : ', variable)
+
+      const rawData = await AssessmentModel.allForAssessmentRaw(
+        appDb,
+        assessment,
+        variable
+      )
+
+      return res.status(200).json({ data: rawData })
+    } catch (error) {
+      return res.status(401).json({ error: error.message })
+    }
+  },
 }
 
 export default assessmentsController

--- a/server/models/AssessmentModel/index.js
+++ b/server/models/AssessmentModel/index.js
@@ -1,8 +1,45 @@
+import { ALL_SUBJECTS_MONGO_PROJECTION, STUDIES_TO_OMIT } from '../../constants'
 import { collections } from '../../utils/mongoCollections'
 
 const AssessmentModel = {
   all: async (db, query) =>
     await db.collection(collections.assessments).find(query).toArray(),
+  allForAssessmentRaw: async (db, assessment, variable) => {
+    console.log('Assesment : ', assessment, 'Variable : ', variable)
+    // const data = this.allForAssessmentRaw(db, chart.assessment, chart.variable)
+    // console.log('Data : ', data)
+    const data = await db
+      .collection(collections.assessmentDayData)
+      .find(
+        {
+          assessment,
+          study: { $nin: STUDIES_TO_OMIT },
+        },
+        {
+          projection: ALL_SUBJECTS_MONGO_PROJECTION,
+        }
+      )
+      .toArray()
+
+    const rawData = {}
+
+    for (const document of data) {
+      const dayData = document.dayData
+      const subjectSite = document.study
+
+      if (!rawData[subjectSite]) {
+        rawData[subjectSite] = []
+      }
+
+      for (const day of dayData) {
+        const rawDayData = day[variable]
+        rawData[subjectSite].push(rawDayData)
+      }
+    }
+
+    console.log('rawData : ', rawData)
+    return rawData
+  },
   upsert: async (db, query, updatedAttributes) =>
     await db.collection(collections.assessments).findOneAndUpdate(
       query,

--- a/server/models/ParticipantsModel/index.js
+++ b/server/models/ParticipantsModel/index.js
@@ -20,11 +20,48 @@ const ParticipantsModel = {
       assessment: chart.assessment,
       study: { $in: filtersService.requestedSites, $nin: STUDIES_TO_OMIT },
     }
+
+    // console.log('Assesment : ', chart.assessment, 'Variable : ', chart.variable)
+    // // const data = this.allForAssessmentRaw(db, chart.assessment, chart.variable)
+    // // console.log('Data : ', data)
+    // const data = await db
+    //   .collection(collections.assessmentDayData)
+    //   .find(
+    //     {
+    //       assessment: chart.assessment,
+    //       study: { $nin: STUDIES_TO_OMIT },
+    //     },
+    //     {
+    //       projection: ALL_SUBJECTS_MONGO_PROJECTION,
+    //     }
+    //   )
+    //   .toArray()
+
+    // const rawData = {}
+
+    // for (const document of data) {
+    //   const dayData = document.dayData
+    //   const subjectSite = document.study
+
+    //   if (!rawData[subjectSite]) {
+    //     rawData[subjectSite] = []
+    //   }
+
+    //   for (const day of dayData) {
+    //     const rawDayData = day[chart.variable]
+    //     rawData[subjectSite].push(rawDayData)
+    //   }
+    // }
+
+    // console.log('rawData : ', rawData)
+
     if (filtersService.allFiltersInactive()) {
-      return await db
+      const data = await db
         .collection(collections.assessmentDayData)
         .find(query, { projection: ALL_SUBJECTS_MONGO_PROJECTION })
         .stream()
+
+      return data
     }
 
     const groupedParticipants = await Promise.all(

--- a/server/routes/assessments.js
+++ b/server/routes/assessments.js
@@ -20,4 +20,8 @@ router
     assessmentsController.index
   )
 
+router
+  .route(v1Routes.assessments.rawData)
+  .get(ensureAuthenticated, assessmentsController.raw)
+
 export default router

--- a/server/utils/routes.js
+++ b/server/utils/routes.js
@@ -14,6 +14,7 @@ export const routes = {
 export const v1Routes = {
   assessments: {
     index: `${v1Root}/assessments`,
+    rawData: `${v1Root}/assessments/:assessment/data/:variable`,
   },
   assessmentData: {
     index: `${v1Root}/import/data/day`,

--- a/views/api/assessments/index.js
+++ b/views/api/assessments/index.js
@@ -4,6 +4,8 @@ import http from '../http'
 const assessments = {
   loadAll: async (queryParams) =>
     http.get(apiRoutes.assessments.index, queryParams),
+  rawData: async (assessment, variable) =>
+    http.get(apiRoutes.assessments.rawData(assessment, variable)),
 }
 
 export default assessments

--- a/views/routes/routes.js
+++ b/views/routes/routes.js
@@ -33,8 +33,8 @@ export const routes = {
   viewChart: (chartId, queryParams) =>
     queryParams
       ? `/charts/${chartId}${qs.stringify(queryParams, {
-          addQueryPrefix: true,
-        })}`
+        addQueryPrefix: true,
+      })}`
       : `/charts/${chartId}`,
   viewChartPage: '/charts/:chart_id',
   viewConfiguration: (configId) => `/u/configure?s=view&id=${configId}`,
@@ -51,6 +51,8 @@ export const apiRoutes = {
   },
   assessments: {
     index: `${apiPath}/assessments`,
+    rawData: (assessment, variable) =>
+      `${apiPath}/assessments/${assessment}/data/${variable}`,
   },
   auth: {
     login: `${apiPath}/login`,


### PR DESCRIPTION
This commit adds a new endpoint `/assessments/:assessment/data/:variable` to retrieve raw data for a specific assessment and variable. The code changes include 
- adding a new method `allForAssessmentRaw` to the `AssessmentModel` that fetches the raw data from the database and returns it in the response.
  - This endpoint will be used to fetch raw data for assessments in the frontend.