### PR TITLE
Apply basic updates to configuration form

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   node-app:
     build:

--- a/server/controllers/configurationsController/index.js
+++ b/server/controllers/configurationsController/index.js
@@ -9,7 +9,8 @@ const ConfigurationsController = {
       const { appDb } = req.app.locals
       const newConfiguration = await ConfigModel.create(appDb, {
         ...req.body,
-        created: new Date().toUTCString(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       return res.status(200).json({ data: newConfiguration })
@@ -46,7 +47,7 @@ const ConfigurationsController = {
       const { config_id } = req.params
       const updatedConfiguration = await ConfigModel.update(appDb, config_id, {
         ...req.body,
-        updatedAt: new Date().toISOString(),
+        updatedAt: new Date(),
       })
 
       return res.status(200).json({ data: updatedConfiguration })

--- a/server/models/ConfigModel/index.js
+++ b/server/models/ConfigModel/index.js
@@ -8,7 +8,11 @@ const ConfigModel = {
     await db
       .collection(collections.configs)
       .aggregate([
-        { $match: { $or: [{ readers: userId }, { public: true }] } },
+        {
+          $match: {
+            $or: [{ readers: userId }, { public: true }, { owner: userId }],
+          },
+        },
         {
           $match: { $or: [{ status: { $exists: false } }, { status: 1 }] },
         },
@@ -17,7 +21,9 @@ const ConfigModel = {
   all: async (db, userId) =>
     await db
       .collection(collections.configs)
-      .find({ $or: [{ readers: userId }, { public: true }] })
+      .find({
+        $or: [{ readers: userId }, { public: true }, { owner: userId }],
+      })
       .stream(),
   destroy: async (db, configId) => {
     const { deletedCount } = await db

--- a/views/components/PageHeader/PageHeader.css
+++ b/views/components/PageHeader/PageHeader.css
@@ -1,0 +1,46 @@
+.PageHeader {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  column-gap: 20px;
+  padding-bottom: 20px;
+}
+.PageHeaderTitle {
+  font-weight: 600;
+  font-size: 16px;
+  grid-column-start: 1;
+  flex-grow: 0.1;
+  padding-top: 10px;
+}
+.PageHeaderCTA {
+  grid-column-start: 4;
+  grid-column-end: 6;
+  align-content: center;
+}
+.PageHeaderDescription {
+  grid-column-start: 1;
+  grid-column-end: 5;
+}
+
+@media screen and (max-width: 1200px) {
+  .PageHeader {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    column-gap: 20px;
+    padding-bottom: 20px;
+  }
+  .PageHeaderCTA {
+    grid-column-start: 1;
+    align-content: center;
+  }
+  .PageHeaderDescription {
+    grid-column-start: 1;
+  }
+}
+
+@media screen and (min-width: 2000px) {
+  .PageHeaderCTA {
+    grid-column-start: 5;
+    grid-column-end: 6;
+    align-content: center;
+  }
+}

--- a/views/components/PageHeader/index.jsx
+++ b/views/components/PageHeader/index.jsx
@@ -3,18 +3,11 @@ import React from 'react'
 import { ArrowBack } from '@mui/icons-material'
 import { Box, Typography, IconButton } from '@mui/material'
 
-import { fontSize } from '../../../constants'
+import './PageHeader.css'
 
 const PageHeader = (props) => {
   return props.isDescription ? (
-    <Box
-      sx={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(5,1fr)',
-        columnGap: '20px',
-        pb: '20px',
-      }}
-    >
+    <Box className="PageHeader">
       <IconButton
         aria-label="back"
         onClick={props.onNavigate}
@@ -27,22 +20,9 @@ const PageHeader = (props) => {
         <ArrowBack />
       </IconButton>
 
-      <Typography
-        sx={{
-          fontWeight: 600,
-          width: 192,
-          fontSize: fontSize[16],
-          gridColumnStart: 1,
-          gridColumnEnd: 5,
-          pt: '10px',
-        }}
-      >
-        {props.title}
-      </Typography>
-
-      <div style={{ gridColumnStart: 1, gridColumnEnd: 5 }}>
-        {props.description}
-      </div>
+      <Typography className="PageHeaderTitle">{props.title}</Typography>
+      {props.cta && <Box className="PageHeaderCTA">{props.cta}</Box>}
+      <div className="PageHeaderDescription">{props.description}</div>
     </Box>
   ) : (
     <Box
@@ -55,7 +35,7 @@ const PageHeader = (props) => {
         alignItems: { xs: 'left', lg: 'center' },
       }}
     >
-      <Typography sx={{ fontWeight: 600, width: 192 }}>
+      <Typography sx={{ fontWeight: 600, flexGrow: 0.1 }}>
         {props.title}
       </Typography>
 

--- a/views/forms/BarChartFields/index.jsx
+++ b/views/forms/BarChartFields/index.jsx
@@ -57,6 +57,7 @@ const BarChartFields = ({
           id="public_checkbox"
           aria-label
           label="Public"
+          labelprops={{}}
         />
       </div>
       {fields.map((field, index) => {

--- a/views/forms/ChartsSearchForm/index.jsx
+++ b/views/forms/ChartsSearchForm/index.jsx
@@ -35,7 +35,7 @@ const ChartsSearchForm = ({ initialValues, onSubmit }) => {
           (e) => onSubmit({ [e.target.name]: e.target.value }),
           500
         )}
-        inputProps={{ autoComplete: 'off' }}
+        InputProps={{ autoComplete: 'off' }}
       />
     </form>
   )

--- a/views/forms/ConfigAssessmentFormFields/index.jsx
+++ b/views/forms/ConfigAssessmentFormFields/index.jsx
@@ -92,9 +92,10 @@ const ConfigAssessmentFormFields = ({
         control={control}
         name={`config.${index}.text`}
         label="Display value"
-        labelPlacement="end"
+        labelplacement="end"
         icon={<VisibilityOffOutlined />}
         checkedIcon={<Visibility />}
+        labelprops={{}}
       />
     </ConfigurationCategoryCard>
   )

--- a/views/forms/ConfigFields/ConfigFields.css
+++ b/views/forms/ConfigFields/ConfigFields.css
@@ -2,4 +2,5 @@
   display: flex;
   gap: 10px;
   flex-flow: wrap;
+  padding-top: 40px;
 }

--- a/views/forms/ConfigFields/index.jsx
+++ b/views/forms/ConfigFields/index.jsx
@@ -13,12 +13,19 @@ const ConfigFormFields = ({
   onCopy,
   onRemove,
   assessmentOptions,
-  handleClearAssessments,
   handleAssessmentSearch,
+  handleClearAssessments,
+  handleClearUsers,
+  handleSelectAllUsers,
 }) => {
   return (
     <>
-      <ConfigTypeFormFields control={control} friendsList={friendsList} />
+      <ConfigTypeFormFields
+        control={control}
+        friendsList={friendsList}
+        handleClearUsers={handleClearUsers}
+        handleSelectAllUsers={handleSelectAllUsers}
+      />
       <div className="ConfigFields">
         {fields.map((field, index) => {
           const { id, ...rest } = field

--- a/views/forms/ConfigForm/ConfigForm.css
+++ b/views/forms/ConfigForm/ConfigForm.css
@@ -9,3 +9,9 @@
   gap: 10px;
   font-size: 12px;
 }
+
+@media screen and (min-width: 1000px) {
+  .ConfigForm {
+    padding-top: 40px;
+  }
+}

--- a/views/forms/ConfigForm/ConfigForm.test.jsx
+++ b/views/forms/ConfigForm/ConfigForm.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import ConfigForm from '.'
+import { colorList } from '../../fe-utils/colorList'
+import { UserConfigModel } from '../../models'
+
+describe('ConfigForm', () => {
+  const defaultProps = {
+    colors: colorList(),
+    friendsList: [
+      { label: 'user 1', value: 'user 1' },
+      { label: 'user 2', value: 'user 2' },
+    ],
+    initialValues: UserConfigModel.defaultFormValues({
+      readers: [],
+      owner: 'user 1',
+    }),
+    handleClearAssessments: () => {},
+    handleAssessmentSearch: () => {},
+    handleSubmitDraft: () => {},
+    onSubmit: () => {},
+  }
+  const elements = {
+    configNameInput: () =>
+      screen.getByRole('textbox', { name: 'Configuration name' }),
+    description: () =>
+      screen.getByRole('textbox', { name: 'Description (Optional)' }),
+    submitAsDraft: () => screen.getByText('Save as draft'),
+    publishConfig: () => screen.getByText('Publish'),
+    makePublic: () => screen.getByRole('checkbox', { name: 'public' }),
+  }
+  const renderForm = (props = defaultProps) => {
+    return render(<ConfigForm {...props} />)
+  }
+
+  it('calls the onSubmit prop when the form is submitted with valid data', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn()
+    const props = { ...defaultProps, onSubmit }
+
+    renderForm(props)
+    await user.type(elements.configNameInput(), 'my config')
+    await user.type(elements.description(), 'description')
+    await user.click(elements.makePublic())
+
+    await user.click(elements.publishConfig())
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          config: [],
+          configName: 'my config',
+          configType: 'matrix',
+          description: 'description',
+          owner: 'user 1',
+          public: true,
+          readers: [],
+        },
+        expect.anything()
+      )
+    )
+  })
+  it('calls the save as draft prop when the form is saved as a draft configuration', async () => {
+    const user = userEvent.setup()
+    const handleSubmitDraft = jest.fn()
+    const props = { ...defaultProps, handleSubmitDraft }
+
+    renderForm(props)
+    await user.type(elements.configNameInput(), 'draft config')
+    await user.type(elements.description(), 'draft')
+    await user.click(elements.submitAsDraft())
+
+    await waitFor(() =>
+      expect(handleSubmitDraft).toHaveBeenCalledWith(
+        {
+          config: [],
+          configName: 'draft config',
+          configType: 'matrix',
+          description: 'draft',
+          owner: 'user 1',
+          public: false,
+          readers: [],
+        },
+        expect.anything()
+      )
+    )
+  })
+})

--- a/views/forms/ConfigForm/index.jsx
+++ b/views/forms/ConfigForm/index.jsx
@@ -13,6 +13,7 @@ import './ConfigForm.css'
 const schema = yup.object({
   configName: yup.string().required(),
   configType: yup.string().required(),
+  description: yup.string(),
   readers: yup.array().of(
     yup.object({
       value: yup.string(),
@@ -49,7 +50,7 @@ const ConfigForm = ({
 }) => {
   const defaultFieldValue = UserConfigModel.defaultConfigValues
 
-  const { handleSubmit, control, getValues } = useForm({
+  const { handleSubmit, control, getValues, setValue } = useForm({
     defaultValues: initialValues,
     resolver: yupResolver(schema),
   })
@@ -58,12 +59,13 @@ const ConfigForm = ({
     name: 'config',
     defaultFieldValue,
   })
-
   const onCopy = (configCategoryIndex) =>
     addNewField(getValues(`config[${configCategoryIndex}]`))
+  const handleClearUsers = () => setValue('readers', [])
+  const handleSelectAllUsers = () => setValue('readers', friendsList)
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className="ConfigForm">
       <ConfigFormFields
         control={control}
         fields={fields}
@@ -74,6 +76,8 @@ const ConfigForm = ({
         assessmentOptions={assessmentOptions}
         handleAssessmentSearch={handleAssessmentSearch}
         handleClearAssessments={handleClearAssessments}
+        handleClearUsers={handleClearUsers}
+        handleSelectAllUsers={handleSelectAllUsers}
       />
       <div className="ConfigFormActions">
         <Button

--- a/views/forms/ConfigTypeFormFields/ConfigTypeFormFields.css
+++ b/views/forms/ConfigTypeFormFields/ConfigTypeFormFields.css
@@ -1,5 +1,41 @@
-@media screen and (min-width: 900px) {
+.ConfigTypeFormFields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    'name type'
+    'description share';
+  grid-gap: 10%;
+}
+.ConfigTypeShareContainer {
+  display: flex;
+  grid-area: share;
+  flex-direction: column;
+}
+.ConfigTypeShareHeader {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas: 'share_label make_public';
+}
+
+@media screen and (max-width: 1100px) {
   .ConfigTypeFormFields {
-    width: 50%;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'name'
+      'type'
+      'description'
+      'share';
+    grid-gap: 15px;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .ConfigTypeShareHeader {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'make_public'
+      'share_label';
   }
 }

--- a/views/forms/ConfigTypeFormFields/index.jsx
+++ b/views/forms/ConfigTypeFormFields/index.jsx
@@ -1,50 +1,108 @@
 import React from 'react'
 
-import { Typography } from '@mui/material'
+import { FormHelperText, InputLabel } from '@mui/material'
 
+import { fontSize, lineHeight } from '../../../constants'
 import ControlledCheckbox from '../ControlledCheckbox'
 import ControlledMultiSelect from '../ControlledMultiSelect'
 import TextInput from '../TextInput'
 
 import './ConfigTypeFormFields.css'
 
+const textInputStyles = {
+  color: 'text.primary',
+  fontWeight: 500,
+  lineHeight: lineHeight[21],
+  fontSize: fontSize[18],
+  mt: '-10px',
+}
+const textInputProps = { notched: false }
+const inputLabelProps = { shrink: true, sx: textInputStyles }
+
 const ConfigTypeFormFields = (props) => {
-  const { control, friendsList } = props
+  const { control, friendsList, handleClearUsers, handleSelectAllUsers } = props
 
   return (
     <div className="ConfigTypeFormFields">
       <TextInput
-        name="configName"
-        label="Configuration Name"
-        margin="normal"
         control={control}
-        required
-        fullWidth
+        name="configName"
+        sx={{
+          gridArea: 'name',
+        }}
+        label="Configuration name"
+        InputLabelProps={inputLabelProps}
+        InputProps={textInputProps}
       />
       <TextInput
+        control={control}
         name="configType"
-        control={control}
+        sx={{
+          gridArea: 'type',
+        }}
+        label="Type"
+        InputLabelProps={inputLabelProps}
+        InputProps={textInputProps}
         disabled
-        value="matrix"
-        label="matrix"
-        fullWidth
       />
-      <Typography variant="subtitle2">Shared with:</Typography>
-      <ControlledMultiSelect
-        name="readers"
+      <TextInput
         control={control}
-        options={friendsList}
-        isMulti
+        name="description"
+        sx={{
+          gridArea: 'description',
+        }}
+        label="Description (Optional)"
+        InputLabelProps={inputLabelProps}
+        InputProps={textInputProps}
       />
-      <div style={{ paddingTop: '15px' }}>
-        <ControlledCheckbox
+      <div className="ConfigTypeShareContainer">
+        <div className="ConfigTypeShareHeader">
+          <InputLabel
+            aria-label="readers"
+            shrink
+            sx={{
+              color: 'text.primary',
+              fontWeight: 500,
+              lineHeight: lineHeight[21],
+              fontSize: fontSize[18],
+              gridColumnStart: 1,
+              gridColumnEnd: 1,
+              gridArea: 'share_label',
+            }}
+          >
+            Share with
+          </InputLabel>
+          <ControlledCheckbox
+            control={control}
+            name="public"
+            id="public_checkbox"
+            aria-label
+            label="Make configuration public"
+            labelplacement="end"
+            sx={{
+              gridColumnStart: 2,
+              gridColumnEnd: 2,
+              color: 'primary.light',
+              '&.Mui-checked': {
+                color: 'primary.light',
+              },
+              gridArea: 'make_public',
+            }}
+            labelprops={{ sx: { height: '20px', mt: '-5px' } }}
+          />
+        </div>
+        <ControlledMultiSelect
+          name="readers"
           control={control}
-          name="public"
-          color="default"
-          id="public_checkbox"
-          label="Public"
-          aria-label
+          options={friendsList}
+          onClear={handleClearUsers}
+          onSelectAll={handleSelectAllUsers}
+          displayActions
+          isMulti
         />
+        <FormHelperText sx={{ color: 'black.A100' }}>
+          Added users will have view only access to this configuration.
+        </FormHelperText>
       </div>
     </div>
   )

--- a/views/forms/ControlledCheckbox/index.jsx
+++ b/views/forms/ControlledCheckbox/index.jsx
@@ -36,7 +36,8 @@ const ControlledCheckbox = ({
         />
       }
       label={label}
-      labelPlacement={props.labelPlacement || 'start'}
+      labelPlacement={props.labelplacement || 'start'}
+      sx={props.labelprops.sx || {}}
     />
   ) : (
     <Controller

--- a/views/forms/DropdownCheckboxGroup/index.jsx
+++ b/views/forms/DropdownCheckboxGroup/index.jsx
@@ -9,7 +9,6 @@ import {
   Button,
 } from '@mui/material'
 import { useController } from 'react-hook-form'
-
 const ITEM_HEIGHT = 48
 const ITEM_PADDING_TOP = 8
 const MenuProps = {
@@ -75,5 +74,4 @@ const DropdownCheckboxGroup = ({
     </Select>
   )
 }
-
 export default DropdownCheckboxGroup

--- a/views/forms/MultiSelect/MultiSelect.css
+++ b/views/forms/MultiSelect/MultiSelect.css
@@ -1,0 +1,5 @@
+.MultiSelectActions {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/views/forms/MultiSelect/MultiSelectActions.jsx
+++ b/views/forms/MultiSelect/MultiSelectActions.jsx
@@ -1,0 +1,29 @@
+import { Paper, Button } from '@mui/material'
+
+import './MultiSelect.css'
+
+const MultiSelectFooterActions = ({
+  children,
+  onClear,
+  onSelectAll,
+  ...rest
+}) => {
+  // Prevent input blur which triggers closing the menu
+  const preventClosingThePopup = (e) => e.preventDefault()
+
+  return (
+    <Paper {...rest}>
+      {children}
+      <div className="MultiSelectActions">
+        <Button onMouseDown={preventClosingThePopup} onClick={onClear}>
+          Clear
+        </Button>
+        <Button onMouseDown={preventClosingThePopup} onClick={onSelectAll}>
+          Select all
+        </Button>
+      </div>
+    </Paper>
+  )
+}
+
+export default MultiSelectFooterActions

--- a/views/forms/MultiSelect/index.jsx
+++ b/views/forms/MultiSelect/index.jsx
@@ -2,12 +2,15 @@ import React from 'react'
 
 import { Autocomplete, Chip, TextField } from '@mui/material'
 
+import MultiSelectFooterActions from './MultiSelectActions'
+
 export const MultiSelect = (props) => {
   const { field, fieldState } = props
 
   return (
     <Autocomplete
       id={props.name}
+      data-testid={props.name}
       fullWidth={props.fullWidth}
       getOptionDisabled={(option) => option.isFixed}
       isOptionEqualToValue={(option, value) => option.value === value.value}
@@ -44,6 +47,13 @@ export const MultiSelect = (props) => {
       )}
       value={props.value || field.value}
       sx={props.sx || {}}
+      componentsProps={{
+        paper: {
+          onClear: props.onClear || {},
+          onSelectAll: props.onSelectAll || {},
+        },
+      }}
+      PaperComponent={props.displayActions ? MultiSelectFooterActions : null}
     />
   )
 }

--- a/views/forms/RegisterForm/index.jsx
+++ b/views/forms/RegisterForm/index.jsx
@@ -39,7 +39,7 @@ const RegistrationForm = ({ initialValues, onSubmit }) => {
         control={control}
         errors={errors.password}
         fullWidth
-        inputProps={{ 'data-testid': 'pw' }}
+        InputProps={{ 'data-testid': 'pw' }}
         label="Password"
         name="password"
         required
@@ -49,7 +49,7 @@ const RegistrationForm = ({ initialValues, onSubmit }) => {
         control={control}
         errors={errors.confirmPassword}
         fullWidth
-        inputProps={{ 'data-testid': 'confirm-pw' }}
+        InputProps={{ 'data-testid': 'confirm-pw' }}
         label="Confirm Password"
         name="confirmPassword"
         required

--- a/views/forms/ResetPasswordForm/index.jsx
+++ b/views/forms/ResetPasswordForm/index.jsx
@@ -38,7 +38,7 @@ const ResetPasswordForm = ({ initialValues, onCancel, onSubmit }) => {
         control={control}
         errors={errors.password}
         fullWidth
-        inputProps={{ 'data-testid': 'pw' }}
+        InputProps={{ 'data-testid': 'pw' }}
         name="password"
         label="Password"
         type="password"
@@ -49,7 +49,7 @@ const ResetPasswordForm = ({ initialValues, onCancel, onSubmit }) => {
         control={control}
         errors={errors.confirmPassword}
         fullWidth
-        inputProps={{ 'data-testid': 'confirm-pw' }}
+        InputProps={{ 'data-testid': 'confirm-pw' }}
         name="confirmPassword"
         type="password"
         label="Confirm Password"

--- a/views/forms/SignInForm/index.jsx
+++ b/views/forms/SignInForm/index.jsx
@@ -39,7 +39,7 @@ const SignInForm = ({ initialValues, onSubmit }) => {
         control={control}
         errors={errors.password}
         fullWidth
-        inputProps={{ 'data-testid': 'pw' }}
+        InputProps={{ 'data-testid': 'pw' }}
         label="Password"
         margin="normal"
         name="password"

--- a/views/forms/TextInput/index.jsx
+++ b/views/forms/TextInput/index.jsx
@@ -13,15 +13,15 @@ const TextInput = (props) => {
       aria-label={props.label}
       fullWidth={props.fullWidth}
       helperText={errors?.message}
-      InputLabelProps={{ shrink: true }}
-      inputProps={{ ...props.inputProps, autoComplete: 'off' }}
+      InputLabelProps={{ shrink: true, ...props.InputLabelProps }}
+      InputProps={{ ...props.InputProps, autoComplete: 'off' }}
       label={props.label}
       margin={props.margin || 'normal'}
       required={props.required}
       type={props.type || 'text'}
       placeholder={props.placeholder}
       sx={props.sx}
-      size={props.size}
+      size={props.size || 'medium'}
       disabled={props.disabled}
       {...field}
       onChange={(e) => {

--- a/views/forms/TextInputTopLabel/index.jsx
+++ b/views/forms/TextInputTopLabel/index.jsx
@@ -39,7 +39,7 @@ const TextInputTopLabel = (props) => {
         required={props.required}
         type={props.type}
         sx={{ borderRadius: borderRadius[8], ...props.sx }}
-        size={props.size}
+        size={props.size || 'small'}
         disabled={props.disabled}
       />
       {!!errors[props.name] && (

--- a/views/models/UserConfigModel/UserConfigModel.test.js
+++ b/views/models/UserConfigModel/UserConfigModel.test.js
@@ -45,6 +45,7 @@ describe('Models - User Config', () => {
             {
               analysis: '',
               category: '',
+
               color: ['#a6cee3', '#1f78b4', '#b2df8a', '#33a02c', '#fb9a99'],
               label: '',
               range: ['0', '1'],
@@ -53,6 +54,7 @@ describe('Models - User Config', () => {
             },
           ],
         },
+        description: '',
         name: '',
         owner: 'owl',
         readers: ['fang', 'talon', 'mabel'],
@@ -103,9 +105,8 @@ describe('Models - User Config', () => {
         UserConfigModel.defaultFormValues({
           owner: 'owl',
           readers: [
-            { label: 'fang', value: 'fang', isFixed: false },
-            { label: 'talon', value: 'talon', isFixed: false },
-            { label: 'owl', value: 'owl', isFixed: true },
+            { label: 'fang', value: 'fang' },
+            { label: 'talon', value: 'talon' },
           ],
           config: [
             UserConfigModel.defaultConfigValues,

--- a/views/models/UserConfigModel/index.js
+++ b/views/models/UserConfigModel/index.js
@@ -13,6 +13,7 @@ const UserConfigModel = {
   defaultFormValues: (overrides = {}) => ({
     configName: '',
     configType: 'matrix',
+    description: '',
     readers: [],
     config: [],
     public: false,
@@ -29,11 +30,14 @@ const UserConfigModel = {
   processConfigToFormFields: (currentConfig, colors) => {
     const {
       config,
+      description,
       name,
       owner,
       public: publicConfig,
       readers,
       type,
+      updatedAt,
+      status,
     } = currentConfig
     const configKey = Object.keys(config)[0]
     const configCategoryFields = config[configKey].map(
@@ -56,14 +60,18 @@ const UserConfigModel = {
     return {
       configName: name,
       configType: type,
+      description: description || '',
       owner,
-      readers: readers.map((reader) => ({
-        value: reader,
-        label: reader,
-        isFixed: reader === owner,
-      })),
+      readers: readers
+        .map((reader) => ({
+          value: reader,
+          label: reader,
+        }))
+        .filter(({ label }) => label !== owner),
       config: configCategoryFields,
       public: publicConfig,
+      updatedAt,
+      status,
     }
   },
   isActive: (configuration, property) =>
@@ -84,11 +92,12 @@ const processConfigAssessment = (formValues, colors, owner) => {
         }
       }),
     },
+    description: formValues.description,
     name: formValues.configName,
-    owner,
-    type: formValues.configType,
-    readers: formValues.readers.map(({ value }) => value),
     public: formValues.public,
+    owner,
+    readers: formValues.readers.map(({ value }) => value),
+    type: formValues.configType,
   }
 }
 

--- a/views/pages/EditConfigPage.jsx
+++ b/views/pages/EditConfigPage.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react'
 
 import { Box, Typography } from '@mui/material'
+import dayjs from 'dayjs'
 import { useParams, useOutletContext } from 'react-router-dom'
 
 import api from '../api'
+import PageHeader from '../components/PageHeader'
 import { colorList } from '../fe-utils/colorList'
 import ConfigForm from '../forms/ConfigForm'
-import { UserConfigModel, UsersModel } from '../models'
+import { UserConfigModel } from '../models'
 
 const colors = colorList()
 
@@ -16,7 +18,9 @@ const EditConfigPage = () => {
   const [initialValues, setInitialValues] = useState({})
   const [loading, setLoading] = useState(true)
   const { config_id } = useParams()
-  const friendsList = UsersModel.createUserFriendList(users, user)
+  const friendsList = users
+    .map(({ uid }) => ({ label: uid, value: uid }))
+    .filter(({ label }) => label !== user.uid)
   const { uid } = user
 
   const handleSubmitPublish = async (formValues) => {
@@ -58,12 +62,6 @@ const EditConfigPage = () => {
   }
 
   const handleClearAssessments = async () => setAssessmentOptions([])
-  useEffect(() => {
-    fetchCurrentConfig().then((values) => {
-      setInitialValues(values)
-      setLoading(false)
-    })
-  }, [])
   const handleSubmitDraft = async (formValues) => {
     const newConfigurationAttributes = UserConfigModel.saveAsDraft(
       formValues,
@@ -81,11 +79,29 @@ const EditConfigPage = () => {
       message: 'Draft saved',
     })
   }
+
+  useEffect(() => {
+    fetchCurrentConfig().then((values) => {
+      setInitialValues(values)
+      setLoading(false)
+    })
+  }, [])
+
   if (loading) return <div>Depending on the size, this may take a while...</div>
 
   return (
     <Box sx={{ p: '30px' }}>
-      <Typography variant="h6">Edit Configuration</Typography>
+      <PageHeader
+        title={initialValues.configName}
+        cta={
+          initialValues.status === 0 ? (
+            <Typography variant="body2" sx={{ color: 'grey.A100' }}>
+              Saved as draft: {dayjs(initialValues.updatedAt).format('llll')}
+            </Typography>
+          ) : null
+        }
+        isDescription
+      />
       <ConfigForm
         assessmentOptions={assessmentOptions}
         colors={colors}

--- a/views/pages/NewConfigPage.jsx
+++ b/views/pages/NewConfigPage.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 
-import { Typography, Box } from '@mui/material'
+import { Box } from '@mui/material'
 import { useOutletContext } from 'react-router-dom'
 
 import api from '../api'
+import PageHeader from '../components/PageHeader'
 import { colorList } from '../fe-utils/colorList'
 import ConfigForm from '../forms/ConfigForm'
-import { UserConfigModel, UsersModel } from '../models'
+import { UserConfigModel } from '../models'
 
 const colors = colorList()
 
@@ -15,10 +16,12 @@ const NewConfigPage = () => {
   const [assessmentOptions, setAssessmentOptions] = useState([])
   const { uid } = user
   const defaultValues = UserConfigModel.defaultFormValues({
-    readers: [{ value: uid, label: uid, isFixed: true }],
+    readers: [],
     owner: uid,
   })
-  const friendsList = UsersModel.createUserFriendList(users, user)
+  const friendsList = users
+    .map(({ uid }) => ({ label: uid, value: uid }))
+    .filter(({ label }) => label !== user.uid)
 
   const handleSubmitPublish = async (formValues) => {
     try {
@@ -56,6 +59,7 @@ const NewConfigPage = () => {
       colors,
       uid
     )
+
     await api.userConfigurations.create(uid, newConfigurationAttributes)
 
     setNotification({
@@ -65,8 +69,8 @@ const NewConfigPage = () => {
   }
 
   return (
-    <Box sx={{ p: '30px' }}>
-      <Typography variant="h6">New Configuration</Typography>
+    <Box sx={{ p: '20px' }}>
+      <PageHeader title="Create new configuration" isDescription />
       <ConfigForm
         colors={colors}
         friendsList={friendsList}


### PR DESCRIPTION
This pr adds basic updates to the configuration form. There is a new field, description being added and we are displaying the date that the configuration was saved as a draft. Configuration owners should not have to be added to the shared list anymore, and the query makes that change and update. To display the bottom action menu, the mui component has props to customize the pop menu and when interacting with these menu items the input loses focus, to remedy this we have a onMouseMove event that stops the focus from moving away from the input which would close the dropdown menu.
There is clean up of warnings on the console from some of the reused components. The form is styled to work in different size screens, and the video displays the functionality of the work.

[video of functionality](https://drive.google.com/file/d/1ub66dxRhulqUe_rb3fNqUf85PXafJ9Yl/view?usp=drive_link)

<img width="770" alt="Screenshot 2024-05-20 at 1 19 32 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/f0d55a4d-8388-4e2b-addf-94442b056819">


<img width="1178" alt="Screenshot 2024-05-20 at 1 19 05 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/5da7f4c8-503b-4da0-a469-4e4481b5c510">
<img width="1370" alt="Screenshot 2024-05-20 at 1 19 14 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/5c641e7c-5d28-45a0-a9d5-99afdd95cfba">
<img width="1024" alt="Screenshot 2024-05-20 at 1 19 24 PM" src="https://github.com/AMP-SCZ/dpdash/assets/19805355/d205d745-fbbb-47a4-a07a-4c9730c368ec">
