### PR TITLE
Insertone to upsert

### DIFF
--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -43,12 +43,15 @@ const AssessmentDayDataController = {
         query
       )
       console.log('PARTICIPANT DATA')
-      console.dir({ participantAssessmentData }, { depth: null })
+      console.dir(
+        { participantAssessmentData, metadata, assessment_variables },
+        { depth: null }
+      )
       let sortedDayData = participant_assessments
       let maxDayInDayData = Math.max(
         ...participant_assessments.map((pa) => pa.day)
       )
-
+      console.dir(participant_assessments, { depth: null })
       if (participantAssessmentData) {
         sortedDayData = sortDayData(
           participantAssessmentData,
@@ -61,18 +64,16 @@ const AssessmentDayDataController = {
         await AssessmentDayDataModel.update(appDb, query, {
           ...participantAssessmentData,
           ...metadata,
-          Consent: parsedConsent,
           daysInStudy: maxDayInDayData,
           dayData: sortedDayData,
         })
         console.log('After AssessmentDayDataModel.update')
       } else {
-        await AssessmentDayDataModel.create(appDb, {
+        await AssessmentDayDataModel.upsert(appDb, query, {
           ...metadata,
-          Consent: parsedConsent,
           dayData: participant_assessments,
         })
-        console.log('After AssessmentDayDataModel.create')
+        console.log('After AssessmentDayDataModel.upsert')
       }
 
       const studyMetadata = await SiteMetadataModel.findOne(appDb, {

--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -71,6 +71,7 @@ const AssessmentDayDataController = {
       } else {
         await AssessmentDayDataModel.upsert(appDb, query, {
           ...metadata,
+          Consent: parsedConsent,
           dayData: participant_assessments,
         })
         console.log('After AssessmentDayDataModel.upsert')

--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -177,15 +177,14 @@ const AssessmentDayDataController = {
       return next(err)
     }
   },
-  destroy: async (req, res) => {
+  destroy: async (req, res, next) => {
     try {
       const { appDb } = req.app.locals
       await appDb.collection(collections.assessmentDayData).drop()
 
       return res.status(200)
     } catch (error) {
-      console.log(error)
-      return res.status(400).json({ message: error.message })
+      next(error)
     }
   },
 }

--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -44,7 +44,13 @@ const AssessmentDayDataController = {
       )
       console.log('PARTICIPANT DATA')
       console.dir(
-        { participantAssessmentData, metadata, assessment_variables },
+        {
+          participantAssessmentData,
+          metadata,
+          assessment_variables,
+          Consent,
+          query,
+        },
         { depth: null }
       )
       let sortedDayData = participant_assessments
@@ -60,7 +66,7 @@ const AssessmentDayDataController = {
         maxDayInDayData = Math.max(
           ...sortedDayData.map((dayData) => dayData.day)
         )
-
+        console.log('Participant data update')
         await AssessmentDayDataModel.update(appDb, query, {
           ...participantAssessmentData,
           ...metadata,
@@ -69,6 +75,7 @@ const AssessmentDayDataController = {
         })
         console.log('After AssessmentDayDataModel.update')
       } else {
+        console.log('NEW PARTICIPANT DATA UPSERT')
         await AssessmentDayDataModel.upsert(appDb, query, {
           ...metadata,
           Consent: parsedConsent,
@@ -84,6 +91,7 @@ const AssessmentDayDataController = {
       console.dir({ studyMetadata }, { depth: null })
 
       if (!studyMetadata) {
+        console.log('new site metadata')
         await SiteMetadataModel.upsert(
           appDb,
           { study },
@@ -112,6 +120,7 @@ const AssessmentDayDataController = {
         console.dir({ isParticipantInDocument }, { depth: null })
 
         if (isParticipantInDocument) {
+          console.log('participant update site metadata upsert')
           await SiteMetadataModel.upsert(
             appDb,
             { participants: { $elemMatch: { participant } } },
@@ -125,6 +134,7 @@ const AssessmentDayDataController = {
           console.log('After participant in document')
           console.dir({ isParticipantInDocument }, { depth: null })
         } else {
+          console.log('new participant site metadata upsert')
           await SiteMetadataModel.upsert(
             appDb,
             { study },

--- a/server/controllers/api/assessmentDayDataController/index.js
+++ b/server/controllers/api/assessmentDayDataController/index.js
@@ -184,6 +184,7 @@ const AssessmentDayDataController = {
 
       return res.status(200)
     } catch (error) {
+      console.log(error)
       return res.status(400).json({ message: error.message })
     }
   },

--- a/server/controllers/api/siteMetadataController/index.js
+++ b/server/controllers/api/siteMetadataController/index.js
@@ -2,7 +2,7 @@ import SiteMetadataModel from '../../../models/SiteMetadataModel'
 import { collections } from '../../../utils/mongoCollections'
 
 const SiteMetadataController = {
-  create: async (req, res) => {
+  create: async (req, res, next) => {
     try {
       const { appDb } = req.app.locals
       const { metadata, participants } = req.body
@@ -67,7 +67,7 @@ const SiteMetadataController = {
 
       return res.status(200).json({ data: 'Metadata imported successfully.' })
     } catch (error) {
-      return res.status(401).json({ message: error.message })
+      next(error)
     }
   },
   destroy: async (req, res) => {

--- a/server/controllers/api/siteMetadataController/siteMetadataController.test.js
+++ b/server/controllers/api/siteMetadataController/siteMetadataController.test.js
@@ -213,7 +213,7 @@ describe('siteMetadataController', () => {
     })
 
     describe('When unsuccessful', () => {
-      it('returns a status of 200 and a success data message', async () => {
+      it('it passess error to next', async () => {
         const body = createSiteMetadata({
           metadata: {
             filetype: 'text/csv',
@@ -249,17 +249,13 @@ describe('siteMetadataController', () => {
 
         const request = createRequest({ body })
         const response = createResponse()
+        const error = new Error('some error')
 
-        request.app.locals.appDb.findOne.mockRejectedValueOnce(
-          new Error('some error')
-        )
+        request.app.locals.appDb.findOne.mockRejectedValueOnce(error)
+        const next = jest.fn()
+        await SiteMetadataController.create(request, response, next)
 
-        await SiteMetadataController.create(request, response)
-
-        expect(response.status).toHaveBeenCalledWith(401)
-        expect(response.json).toHaveBeenCalledWith({
-          message: 'some error',
-        })
+        expect(next).toHaveBeenCalledWith(error)
       })
     })
   })

--- a/server/models/AssessmentDayDataModel/index.js
+++ b/server/models/AssessmentDayDataModel/index.js
@@ -8,10 +8,15 @@ const AssessmentDayDataModel = {
       .toArray(),
   findOne: async (db, query) =>
     await db.collection(collections.assessmentDayData).findOne(query),
-  create: async (db, participantData) =>
-    await db
-      .collection(collections.assessmentDayData)
-      .insertOne(participantData),
+  upsert: async (db, query, updatedAttributes) =>
+    await db.collection(collections.assessmentDayData).findOneAndUpdate(
+      query,
+      { $set: updatedAttributes },
+      {
+        upsert: true,
+        returnDocument: 'after',
+      }
+    ),
   createMany: async (db, assessmentDayData) =>
     await db
       .collection(collections.assessmentDayData)


### PR DESCRIPTION
After reviewing the logs it looks like the insert property is a point where the code stops from executing correctly, this pr changes the insertOne method to an upsert method.

Adds additional logs and other operation errors are funneled to the error logger.

Another possibility is something changed in the data and maybe we have something that documentdb considers an operator.