### PR TITLE
Fix import

### DIFF
--- a/server/controllers/api/siteMetadataController/index.js
+++ b/server/controllers/api/siteMetadataController/index.js
@@ -14,15 +14,13 @@ const SiteMetadataController = {
       const studyMetadata = await SiteMetadataModel.findOne(appDb, { study })
 
       if (!studyMetadata) {
-        await SiteMetadataModel.upsert(
+        await SiteMetadataModel.upsert$Set(
           appDb,
           { study },
           {
-            setAttributes: {
-              ...metadata,
-              participants,
-              createdAt: new Date(),
-            },
+            ...metadata,
+            participants,
+            createdAt: new Date(),
           }
         )
       } else {
@@ -37,10 +35,10 @@ const SiteMetadataController = {
               }
             )
             if (!isParticipantInSiteMetadata) {
-              await SiteMetadataModel.upsert(
+              await SiteMetadataModel.upsert$addToSet(
                 appDb,
                 { study },
-                { addToSetAttributes: { participants: participant } }
+                { participants: participant }
               )
             } else {
               const updatedAttributes = Object.keys(participant).reduce(
@@ -51,14 +49,14 @@ const SiteMetadataController = {
                 },
                 {}
               )
-              await SiteMetadataModel.upsert(
+              await SiteMetadataModel.upsert$Set(
                 appDb,
                 {
                   participants: {
                     $elemMatch: { participant: participant.participant },
                   },
                 },
-                { setAttributes: updatedAttributes }
+                updatedAttributes
               )
             }
           })

--- a/server/models/SiteMetadataModel/index.js
+++ b/server/models/SiteMetadataModel/index.js
@@ -7,14 +7,19 @@ const queryOptions = {
 const SiteMetadataModel = {
   findOne: async (db, query) =>
     await db.collection(collections.metadata).findOne(query),
-  upsert: async (db, query, { setAttributes, addToSetAttributes }) =>
+  upsert$Set: async (db, query, setAttributes) =>
     await db.collection(collections.metadata).findOneAndUpdate(
       query,
       {
-        $set: { ...(setAttributes || {}), updatedAt: new Date() },
-        $addToSet: Object.keys(addToSetAttributes || {}).length
-          ? { ...addToSetAttributes, createdAt: new Date() }
-          : {},
+        $set: setAttributes,
+      },
+      queryOptions
+    ),
+  upsert$addToSet: async (db, query, addToSetAttributes) =>
+    await db.collection(collections.metadata).findOneAndUpdate(
+      query,
+      {
+        $addToSet: addToSetAttributes,
       },
       queryOptions
     ),


### PR DESCRIPTION
This pr fixes the last portion of the dpimport endpoint. The issue is with $set and $addToSet for documentdb it does not support empty objects. To fix this I separated the two methods and tested it with an EC2 and documentdb instance.

